### PR TITLE
ECS S3 read

### DIFF
--- a/terraform/deploy/modules.tf
+++ b/terraform/deploy/modules.tf
@@ -33,14 +33,10 @@ module "prometheus_master" {
   name                       = var.name
   role                       = "master"
   prometheus_version         = var.prometheus_version
-  image                      = data.terraform_remote_state.management.outputs.ecr_prometheus_url
-  lb_listener                = module.lb.outputs.lb_listener
-  lb_security_group_id       = module.lb.outputs.security_group_id
-  fqdn                       = module.lb.outputs.fqdn
+  lb                         = module.lb.outputs
   vpc                        = module.vpc.outputs
-  ecs_task_execution_role    = data.terraform_remote_state.management.outputs.ecs_task_execution_role
-  ecs_cluster_main           = data.terraform_remote_state.management.outputs.ecs_cluster_main
-  ecs_cluster_main_log_group = data.terraform_remote_state.management.outputs.ecs_cluster_main_log_group
+  mgmt                       = data.terraform_remote_state.management.outputs
+  s3_prefix                  = "monitoring/prometheus"
   tags                       = merge(local.tags, { Name = "prometheus" })
 }
 
@@ -50,13 +46,9 @@ module "prometheus_slave" {
   name                       = var.name
   role                       = "slave"
   prometheus_version         = var.prometheus_version
-  image                      = data.terraform_remote_state.management.outputs.ecr_prometheus_url
-  lb_listener                = module.lb.outputs.lb_listener
-  lb_security_group_id       = module.lb.outputs.security_group_id
-  fqdn                       = module.lb.outputs.fqdn
+  lb                         = module.lb.outputs
   vpc                        = module.vpc.outputs
-  ecs_task_execution_role    = data.terraform_remote_state.management.outputs.ecs_task_execution_role
-  ecs_cluster_main           = data.terraform_remote_state.management.outputs.ecs_cluster_main
-  ecs_cluster_main_log_group = data.terraform_remote_state.management.outputs.ecs_cluster_main_log_group
+  mgmt                       = data.terraform_remote_state.management.outputs
+  s3_prefix                  = "monitoring/prometheus"
   tags                       = merge(local.tags, { Name = "prometheus" })
 }

--- a/terraform/modules/prometheus/config/prometheus-master.tpl
+++ b/terraform/modules/prometheus/config/prometheus-master.tpl
@@ -1,20 +1,9 @@
-global:
-  scrape_interval: 15s
-  evaluation_interval: 30s
-  # scrape_timeout is set to the global default (10s).
-
 scrape_configs:
-  - job_name: 'federate'
-    scrape_interval: 15s
+  - job_name: 'ci'
 
-    honor_labels: true
-    metrics_path: '/federate'
-
-    params:
-      'match[]':
-        - '{job="prometheus"}'
-        - '{__name__=~"job:.*"}'
+    metrics_path: /metrics
 
     static_configs:
-      - targets:
-        - 'prometheus-slave:9090'
+      - targets: ['127.0.0.1:9090']
+        labels:
+          group: 'concourse'

--- a/terraform/modules/prometheus/config/prometheus-slave.tpl
+++ b/terraform/modules/prometheus/config/prometheus-slave.tpl
@@ -1,9 +1,9 @@
-global:
-  scrape_interval: 15s
-  evaluation_interval: 30s
-  # scrape_timeout is set to the global default (10s).
-
 scrape_configs:
-   - targets: ['ci.wip.dataworks.dwp.gov.uk:9100/metrics]
+  - job_name: 'ci'
+
+    metrics_path: /metrics
+
+    static_configs:
+      - targets: ['127.0.0.1:9090']
         labels:
           group: 'concourse'

--- a/terraform/modules/prometheus/iam.tf
+++ b/terraform/modules/prometheus/iam.tf
@@ -16,3 +16,46 @@ data "aws_iam_policy_document" "prometheus" {
     }
   }
 }
+
+data "aws_iam_policy_document" "prometheus_read_config" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      var.mgmt.config_bucket.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "${var.mgmt.config_bucket.arn}/${var.s3_prefix}/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+    ]
+
+    resources = [
+      var.mgmt.config_bucket.cmk_arn,
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "prometheus" {
+  policy = data.aws_iam_policy_document.prometheus_read_config.json
+  role   = aws_iam_role.prometheus.id
+}

--- a/terraform/modules/prometheus/security_groups.tf
+++ b/terraform/modules/prometheus/security_groups.tf
@@ -9,13 +9,22 @@ resource "aws_security_group" "web" {
   }
 }
 
+resource "aws_security_group_rule" "allow_egress_https" {
+  type              = "egress"
+  to_port           = 443
+  protocol          = "tcp"
+  prefix_list_ids   = [var.vpc.s3_prefix_list_id]
+  from_port         = 443
+  security_group_id = aws_security_group.web.id
+}
+
 resource "aws_security_group_rule" "allow_ingress_prom" {
   type                     = "ingress"
   to_port                  = 9090
   protocol                 = "tcp"
   from_port                = 9090
   security_group_id        = aws_security_group.web.id
-  source_security_group_id = var.lb_security_group_id
+  source_security_group_id = var.lb.security_group_id
 }
 
 resource "aws_security_group_rule" "allow_egress_prom" {

--- a/terraform/modules/prometheus/target_group.tf
+++ b/terraform/modules/prometheus/target_group.tf
@@ -20,7 +20,7 @@ resource "aws_lb_target_group" "web_http" {
 }
 
 resource "aws_lb_listener_rule" "https" {
-  listener_arn = var.lb_listener
+  listener_arn = var.lb.lb_listener
 
   action {
     type             = "forward"
@@ -29,6 +29,6 @@ resource "aws_lb_listener_rule" "https" {
 
   condition {
     field  = "host-header"
-    values = [var.fqdn]
+    values = [var.lb.fqdn]
   }
 }

--- a/terraform/modules/prometheus/variables.tf
+++ b/terraform/modules/prometheus/variables.tf
@@ -18,29 +18,13 @@ variable "prometheus_version" {
   type        = string
 }
 
-variable "lb_listener" {
-  description = "ARN of the LB Listener"
-  type        = string
-}
-
-variable "fqdn" {
-  description = "Route53 FQDN"
-  type        = string
-}
-
-variable "image" {
+variable "s3_prefix" {
   type = string
 }
 
-variable "lb_security_group_id" {
-  description = ""
-  type        = string
-}
-
+variable "mgmt" {}
 variable "vpc" {}
-variable "ecs_task_execution_role" {}
-variable "ecs_cluster_main_log_group" {}
-variable "ecs_cluster_main" {}
+variable "lb" {}
 
 variable "fargate_cpu" {
   default = "256"


### PR DESCRIPTION
- Simplifying the variables being passed into module to reduce repetition
- Adding 443 Egress rule to allow pulling from S3
- Changing config to basic template as simple placeholder
- Deploying config to S3 and setting environment variables in ECS to read it in