### PR TITLE
Service discovery against concourse EC2 and prometheus ECS instances

### DIFF
--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -75,6 +75,8 @@ meta:
             - |
               cp ../terraform-config/terraform.tf .
               cp ../terraform-config/terraform.tfvars .
+              cp ../terraform-config/vpc.tf modules/vpc/vpc.tf
+              cp ../terraform-config/outputs.tf modules/vpc/outputs.tf
               terraform workspace show
               terraform init
               terraform plan -detailed-exitcode

--- a/config/prometheus-master.tpl
+++ b/config/prometheus-master.tpl
@@ -11,6 +11,6 @@ scrape_configs:
         - '{__name__=~"job:.*"}'
 
     static_configs:
-      - targets: ['127.0.0.1:9090']
+      - targets: ['slave.services.${parent_domain_name}:9090']
         labels:
           group: 'prometheus'

--- a/config/prometheus-slave.tpl
+++ b/config/prometheus-slave.tpl
@@ -1,9 +1,29 @@
+global:
+  scrape_interval: 1m
+  scrape_timeout: 10s
+  evaluation_interval: 1m
 scrape_configs:
-  - job_name: 'ci'
-
-    metrics_path: /metrics
-
-    static_configs:
-      - targets: ['127.0.0.1:9090']
-        labels:
-          group: 'concourse'
+- job_name: ci
+  honor_timestamps: true
+  scrape_interval: 1m
+  scrape_timeout: 10s
+  metrics_path: /metrics
+  scheme: http
+  ec2_sd_configs:
+  - endpoint: ""
+    region: eu-west-2
+    refresh_interval: 1m
+    port: 9090
+    filters: []
+  relabel_configs:
+  - source_labels: [__meta_ec2_tag_Name]
+    separator: ;
+    regex: concourse-web
+    replacement: $1
+    action: keep
+  - source_labels: [__meta_ec2_tag_Name, __meta_ec2_availability_zone]
+    separator: ;
+    regex: (.*)
+    target_label: instance
+    replacement: $1
+    action: replace

--- a/ecs.tf
+++ b/ecs.tf
@@ -81,7 +81,7 @@ resource "aws_ecs_service" "prometheus" {
 
   service_registries {
     registry_arn   = aws_service_discovery_service.prometheus[count.index].arn
-    container_name = "${local.roles[count.index]}-${var.name}"
+    container_name = "${var.name}-${local.roles[count.index]}"
   }
 }
 
@@ -108,7 +108,7 @@ resource "aws_service_discovery_private_dns_namespace" "prometheus" {
 
 resource "aws_service_discovery_service" "prometheus" {
   count = length(local.roles)
-  name  = local.roles[count.index]
+  name  = "${var.name}-${local.roles[count.index]}"
 
   dns_config {
     namespace_id = aws_service_discovery_private_dns_namespace.prometheus.id

--- a/ecs.tf
+++ b/ecs.tf
@@ -78,11 +78,19 @@ resource "aws_ecs_service" "prometheus" {
     container_name   = "${local.roles[count.index]}-${var.name}"
     container_port   = var.prom_port
   }
+
+  service_registries {
+    registry_arn   = aws_service_discovery_service.prometheus[count.index].arn
+    container_name = "${local.roles[count.index]}-${var.name}"
+  }
 }
 
 data template_file "prometheus_config" {
   count    = length(local.roles)
   template = file("${path.module}/config/prometheus-${local.roles[count.index]}.tpl")
+  vars = {
+    parent_domain_name = var.parent_domain_name
+  }
 }
 
 resource "aws_s3_bucket_object" "prometheus_config" {
@@ -91,6 +99,25 @@ resource "aws_s3_bucket_object" "prometheus_config" {
   key        = "${var.s3_prefix}/prometheus-${local.roles[count.index]}.yml"
   content    = data.template_file.prometheus_config[count.index].rendered
   kms_key_id = data.terraform_remote_state.management.outputs.config_bucket.cmk_arn
+}
+
+resource "aws_service_discovery_private_dns_namespace" "prometheus" {
+  name = "services.${var.parent_domain_name}"
+  vpc  = module.vpc.outputs.vpc_ids[0]
+}
+
+resource "aws_service_discovery_service" "prometheus" {
+  count = length(local.roles)
+  name  = local.roles[count.index]
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.prometheus.id
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+  }
 }
 
 resource "aws_lb_target_group" "web_http" {

--- a/iam.tf
+++ b/iam.tf
@@ -54,6 +54,21 @@ data "aws_iam_policy_document" "prometheus_read_config" {
       data.terraform_remote_state.management.outputs.config_bucket.cmk_arn,
     ]
   }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:DescribeInstances",
+      "ec2:DescribeImages",
+      "ec2:DescribeTags",
+      "ec2:DescribeSnapshots"
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
 }
 
 resource "aws_iam_role_policy" "prometheus" {

--- a/peering.tf
+++ b/peering.tf
@@ -1,7 +1,0 @@
-resource "aws_vpc_peering_connection" "peering" {
-  count       = local.roles[0] == "master" ? 1 : 0
-  peer_vpc_id = data.terraform_remote_state.aws_concourse.outputs.route_tables[0].vpc_id
-  vpc_id      = module.vpc.outputs.vpc_ids[0]
-  auto_accept = true
-  tags        = merge(local.tags, { Name = "prometheus_pcx" })
-}

--- a/peering_concourse.tf
+++ b/peering_concourse.tf
@@ -1,13 +1,21 @@
+resource "aws_vpc_peering_connection" "peering" {
+  count       = local.roles[0] == "master" ? 1 : 0
+  peer_vpc_id = data.terraform_remote_state.aws_concourse.outputs.route_tables[0].vpc_id
+  vpc_id      = module.vpc.outputs.vpc_ids[1]
+  auto_accept = true
+  tags        = merge(local.tags, { Name = "prometheus_pcx" })
+}
+
 resource "aws_route" "concourse_route" {
   count                     = local.roles[0] == "master" ? length(data.terraform_remote_state.aws_concourse.outputs.route_tables) : 0
   route_table_id            = data.terraform_remote_state.aws_concourse.outputs.route_tables[count.index].id
-  destination_cidr_block    = local.cidr_block[local.environment].mon-master-vpc
+  destination_cidr_block    = local.cidr_block[local.environment].mon-slave-vpc
   vpc_peering_connection_id = aws_vpc_peering_connection.peering[0].id
 }
 
 resource "aws_route" "route" {
   count                     = local.roles[0] == "master" ? local.zone_count : 0
-  route_table_id            = module.vpc.outputs.private_route_tables[0][count.index]
+  route_table_id            = module.vpc.outputs.private_route_tables[1][count.index]
   destination_cidr_block    = local.cidr_block[local.environment].ci-cd-vpc
   vpc_peering_connection_id = aws_vpc_peering_connection.peering[0].id
 }
@@ -20,7 +28,7 @@ resource "aws_security_group_rule" "web_lb_in_metrics" {
   security_group_id        = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
   to_port                  = 9090
   type                     = "ingress"
-  source_security_group_id = aws_security_group.web[0].id
+  source_security_group_id = aws_security_group.web[1].id
 }
 
 resource "aws_security_group_rule" "allow_egress_prometheus" {
@@ -29,6 +37,6 @@ resource "aws_security_group_rule" "allow_egress_prometheus" {
   to_port           = 9090
   protocol          = "tcp"
   from_port         = 9090
-  security_group_id = aws_security_group.web[count.index].id
+  security_group_id = aws_security_group.web[1].id
   cidr_blocks       = [local.cidr_block[local.environment].ci-cd-vpc]
 }

--- a/peering_concourse.tf
+++ b/peering_concourse.tf
@@ -1,6 +1,6 @@
 resource "aws_vpc_peering_connection" "peering" {
   count       = local.roles[0] == "master" ? 1 : 0
-  peer_vpc_id = data.terraform_remote_state.aws_concourse.outputs.route_tables[0].vpc_id
+  peer_vpc_id = data.terraform_remote_state.aws_concourse.outputs.vpc_id
   vpc_id      = module.vpc.outputs.vpc_ids[1]
   auto_accept = true
   tags        = merge(local.tags, { Name = "prometheus_pcx" })

--- a/peering_concourse.tf
+++ b/peering_concourse.tf
@@ -1,6 +1,6 @@
 resource "aws_vpc_peering_connection" "peering" {
   count       = local.roles[0] == "master" ? 1 : 0
-  peer_vpc_id = data.terraform_remote_state.aws_concourse.outputs.vpc_id
+  peer_vpc_id = data.terraform_remote_state.aws_concourse.outputs.aws_vpc.id
   vpc_id      = module.vpc.outputs.vpc_ids[1]
   auto_accept = true
   tags        = merge(local.tags, { Name = "prometheus_pcx" })

--- a/peering_master.tf
+++ b/peering_master.tf
@@ -22,7 +22,7 @@ resource "aws_route" "master_route" {
 
 resource "aws_security_group_rule" "allow_ingress_master" {
   count                    = local.roles[0] == "master" ? 1 : 0
-  description              = "inbound traffic to web nodes metrics port"
+  description              = "Allow master nodes to reach slave node metrics endpoints"
   from_port                = 9090
   protocol                 = "tcp"
   security_group_id        = aws_security_group.web[1].id
@@ -33,6 +33,7 @@ resource "aws_security_group_rule" "allow_ingress_master" {
 
 resource "aws_security_group_rule" "allow_egress_master" {
   count             = local.roles[0] == "master" ? 1 : 0
+  description       = "Allow master nodes to reach slave node metrics endpoints"
   type              = "egress"
   to_port           = 9090
   protocol          = "tcp"

--- a/peering_master.tf
+++ b/peering_master.tf
@@ -1,0 +1,42 @@
+resource "aws_vpc_peering_connection" "master_slave" {
+  count       = local.roles[0] == "master" ? 1 : 0
+  peer_vpc_id = module.vpc.outputs.vpc_ids[1]
+  vpc_id      = module.vpc.outputs.vpc_ids[0]
+  auto_accept = true
+  tags        = merge(local.tags, { Name = "master_slave" })
+}
+
+resource "aws_route" "slave_route" {
+  count                     = local.roles[0] == "master" ? local.zone_count : 0
+  route_table_id            = module.vpc.outputs.private_route_tables[1][count.index]
+  destination_cidr_block    = local.cidr_block[local.environment].mon-master-vpc
+  vpc_peering_connection_id = aws_vpc_peering_connection.master_slave[0].id
+}
+
+resource "aws_route" "master_route" {
+  count                     = local.roles[0] == "master" ? local.zone_count : 0
+  route_table_id            = module.vpc.outputs.private_route_tables[0][count.index]
+  destination_cidr_block    = local.cidr_block[local.environment].mon-slave-vpc
+  vpc_peering_connection_id = aws_vpc_peering_connection.master_slave[0].id
+}
+
+resource "aws_security_group_rule" "allow_ingress_master" {
+  count                    = local.roles[0] == "master" ? 1 : 0
+  description              = "inbound traffic to web nodes metrics port"
+  from_port                = 9090
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.web[1].id
+  to_port                  = 9090
+  type                     = "ingress"
+  source_security_group_id = aws_security_group.web[0].id
+}
+
+resource "aws_security_group_rule" "allow_egress_master" {
+  count             = local.roles[0] == "master" ? 1 : 0
+  type              = "egress"
+  to_port           = 9090
+  protocol          = "tcp"
+  from_port         = 9090
+  security_group_id = aws_security_group.web[0].id
+  cidr_blocks       = [local.cidr_block[local.environment].mon-slave-vpc]
+}


### PR DESCRIPTION
- EC2 service discovery is used for concourse
- DNS based service discovery is used for prometheus instances 