### PR TITLE
Adding service discovery sidecar and configurations on prometheus

### DIFF
--- a/config/prometheus/prometheus-slave.tpl
+++ b/config/prometheus/prometheus-slave.tpl
@@ -29,3 +29,13 @@ scrape_configs:
     target_label: instance
     replacement: $1
     action: replace
+- job_name: 'ecs-service-discovery'
+  scrape_interval: 1m
+  file_sd_configs:
+    - files:
+        - /prometheus/ecs/1m-tasks.json
+  relabel_configs:
+    - source_labels: [metrics_path]
+      action: replace
+      target_label: __metrics_path__
+      regex: (.+)

--- a/ecs_prometheus.tf
+++ b/ecs_prometheus.tf
@@ -115,7 +115,7 @@ resource "aws_ecs_task_definition" "prometheus" {
   },
   {
     "cpu": ${var.fargate_cpu},
-    "image": "${data.terraform_remote_state.management.outputs.ecr_ecs_service_discovery_url}:debug",
+    "image": "${data.terraform_remote_state.management.outputs.ecr_ecs_service_discovery_url}",
     "memory": ${var.fargate_memory},
     "name": "ecs-service-discovery",
     "networkMode": "awsvpc",

--- a/ecs_prometheus.tf
+++ b/ecs_prometheus.tf
@@ -2,7 +2,7 @@ resource "aws_ecs_task_definition" "prometheus" {
   family                   = "prometheus"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = "512"
+  cpu                      = "1024"
   memory                   = "4096"
   task_role_arn            = aws_iam_role.prometheus.arn
   execution_role_arn       = local.is_management_env ? data.terraform_remote_state.management.outputs.ecs_task_execution_role.arn : data.terraform_remote_state.common.outputs.ecs_task_execution_role.arn
@@ -110,6 +110,40 @@ resource "aws_ecs_task_definition" "prometheus" {
       {
         "name": "THANOS_CONFIG_S3_PREFIX",
         "value": "${var.name}/thanos"
+      }
+    ]
+  },
+  {
+    "cpu": ${var.fargate_cpu},
+    "image": "${data.terraform_remote_state.management.outputs.ecr_ecs_service_discovery_url}:debug",
+    "memory": ${var.fargate_memory},
+    "name": "ecs-service-discovery",
+    "networkMode": "awsvpc",
+    "user": "nobody",
+    "mountPoints": [
+      {
+        "containerPath": "/prometheus",
+        "sourceVolume": "prometheus"
+      }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${aws_cloudwatch_log_group.monitoring.name}",
+        "awslogs-region": "${data.aws_region.current.name}",
+        "awslogs-stream-prefix": "ecs-service-discovery"
+      }
+    },
+    "placementStrategy": [
+      {
+        "field": "attribute:ecs.availability-zone",
+        "type": "spread"
+      }
+    ],
+    "environment": [
+      {
+        "name": "SERVICE_DISCOVERY_DIRECTORY",
+        "value": "/prometheus/ecs"
       }
     ]
   }
@@ -276,7 +310,9 @@ data "aws_iam_policy_document" "prometheus_service_discovery" {
 
     actions = [
       "ec2:DescribeInstances",
-      "ec2:DescribeTags"
+      "ec2:DescribeTags",
+      "ecs:Describe*",
+      "ecs:List*"
     ]
 
     resources = [


### PR DESCRIPTION
- Adding ECS service discovery sidecar to prometheus container
- Shares EFS volume with prometheus to write out discovered target every 60s
- Prometheus reads discovered target in config