### PR TITLE
Outofband Alerts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ bootstrap: ## Bootstrap local environment for first use
 		export AWS_PROFILE=$(aws_profile); \
 		export AWS_REGION=$(aws_region); \
 		python3 bootstrap_terraform.py; \
-		python3 bootstrap_ci_pipeline.py; \
 	}
 	terraform fmt -recursive
 

--- a/config/prometheus/outofband-rules.tpl
+++ b/config/prometheus/outofband-rules.tpl
@@ -1,10 +1,34 @@
 groups:
-- name: alert.rules
+- name: outofband_alert.rules
   rules:
-  - alert: OutOfBandSimpleAlert
+  - alert: ThanosRulerAlertSendFailure
     annotations:
-      message: Simple alert to test outofband alerting
-    expr: up == 1
-    for: 15s
+      message: Thanos ruler failed to send alert to alertmanager
+    expr: rate(thanos_alert_sender_alerts_dropped_total)[30s] > 0
+    for: 30s
+    labels:
+      severity: warning
+
+  - alert: ThanosRulerEvaluationFailure
+    annotations:
+      message: Thanos ruler failed to evaluate rule indication possible query API issue
+    expr: rate(prometheus_rule_evaluation_failures_total)[30s] > 0
+    for: 30s
+    labels:
+      severity: warning
+
+  - alert: ThanosRulerSlowEvaluation
+    annotations:
+      message: Thanos ruler is taking longer to evaluate than specified evaluation interval
+    expr: prometheus_rule_group_last_duration_seconds < prometheus_rule_group_interval_seconds
+    for: 30s
+    labels:
+      severity: warning
+
+  - alert: ThanosRulerAlertSendFailure
+    annotations:
+      message: Thanos ruler failed to send alert to alertmanager
+    expr: rate(thanos_rule_evaluation_with_warnings_total)[30s] > 0
+    for: 30s
     labels:
       severity: warning

--- a/config/prometheus/outofband-rules.tpl
+++ b/config/prometheus/outofband-rules.tpl
@@ -1,34 +1,34 @@
 groups:
-- name: outofband_alert.rules
+- name: outofbandalert.rules
   rules:
   - alert: ThanosRulerAlertSendFailure
     annotations:
       message: Thanos ruler failed to send alert to alertmanager
-    expr: rate(thanos_alert_sender_alerts_dropped_total)[30s] > 0
-    for: 30s
+    expr: rate(thanos_alert_sender_alerts_dropped_total[30s]) > 0
+    for: 0s
     labels:
       severity: warning
 
   - alert: ThanosRulerEvaluationFailure
     annotations:
       message: Thanos ruler failed to evaluate rule indication possible query API issue
-    expr: rate(prometheus_rule_evaluation_failures_total)[30s] > 0
-    for: 30s
+    expr: rate(prometheus_rule_evaluation_failures_total[30s]) > 0
+    for: 0s
     labels:
       severity: warning
 
   - alert: ThanosRulerSlowEvaluation
     annotations:
       message: Thanos ruler is taking longer to evaluate than specified evaluation interval
-    expr: prometheus_rule_group_last_duration_seconds < prometheus_rule_group_interval_seconds
-    for: 30s
+    expr: prometheus_rule_group_interval_seconds < prometheus_rule_group_last_duration_seconds
+    for: 0s
     labels:
       severity: warning
 
-  - alert: ThanosRulerAlertSendFailure
+  - alert: ThanosRulerEvaluationWarnings
     annotations:
       message: Thanos ruler failed to send alert to alertmanager
-    expr: rate(thanos_rule_evaluation_with_warnings_total)[30s] > 0
-    for: 30s
+    expr: rate(thanos_rule_evaluation_with_warnings_total[30s]) > 0
+    for: 0s
     labels:
       severity: warning

--- a/config/thanos/rules/alert.rules.yaml
+++ b/config/thanos/rules/alert.rules.yaml
@@ -4,7 +4,7 @@ groups:
   - alert: SimpleAlert
     annotations:
       message: Simple alert to ensure query node is running
-    expr: vector(1)
+    expr: vector(1) < 1
     for: 0s
     labels:
       severity: warning


### PR DESCRIPTION
- This turned out to be simpler than expected. If an alert fails to be evaluated on the Thanos Ruler, it does not fire, so silencing doesn't need to be carried out as I expected.