### PR TITLE
yace migration

### DIFF
--- a/config/cloudwatch-exporter/config.tpl
+++ b/config/cloudwatch-exporter/config.tpl
@@ -1,7 +1,12 @@
----
-region: ${region}
-metrics:
-- aws_namespace: AWS/ELB
-  aws_metric_name: HealthyHostCount
-  aws_dimensions: [AvailabilityZone, LoadBalancerName]
-  aws_statistics: [Average]
+discovery:
+  jobs:
+  - regions:
+      - ${region}
+    type: elb
+    enableMetricData: true
+    metrics:
+      - name: ActiveConnectionCount
+        statistics:
+        - Sum
+        period: 300
+        length: 600

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "alertmanager_port" {
 }
 
 variable "cloudwatch_exporter_port" {
-  default = 9106
+  default = 5000
 }
 
 variable "subnets" {


### PR DESCRIPTION
Migrating to yet another cloudwatch exporter.

The configuration is a placeholder, the capturing of valid ADG metrics will be carried out later