### PR TITLE
Allow anon logins as viewers

### DIFF
--- a/config/grafana/grafana.ini
+++ b/config/grafana/grafana.ini
@@ -41,7 +41,9 @@ cookie_secure = true
 
 #################################### Anonymous Auth ######################
 [auth.anonymous]
-
+enabled = true
+org_name = Main Org.
+org_role = Viewer
 #################################### Github Auth ##########################
 [auth.github]
 


### PR DESCRIPTION
Allow anonymous logins to Grafana, and for those sessions to be viewers.