### PR TITLE
rm efs, bump cpu/mem resource

### DIFF
--- a/container_definition.tpl
+++ b/container_definition.tpl
@@ -2,6 +2,7 @@
   "cpu": ${cpu},
   "image": "${image_url}",
   "memory": ${memory},
+  "memory_reservation": ${memory_reservation},
   "name": "${name}",
   "networkMode": "awsvpc",
   "user": "${user}",

--- a/outofband_ecs.tf
+++ b/outofband_ecs.tf
@@ -28,17 +28,18 @@ data "template_file" "outofband_definition" {
   count    = local.is_management_env ? 1 : 0
   template = file("${path.module}/container_definition.tpl")
   vars = {
-    name          = "outofband"
-    group_name    = "prometheus"
-    cpu           = var.fargate_cpu
-    image_url     = data.terraform_remote_state.management.outputs.ecr_prometheus_url
-    memory        = var.fargate_memory
-    user          = "nobody"
-    ports         = jsonencode([var.prometheus_port])
-    ulimits       = jsonencode([])
-    log_group     = aws_cloudwatch_log_group.monitoring.name
-    region        = data.aws_region.current.name
-    config_bucket = local.is_management_env ? data.terraform_remote_state.management.outputs.config_bucket.id : data.terraform_remote_state.common.outputs.config_bucket.id
+    name               = "outofband"
+    group_name         = "prometheus"
+    cpu                = var.fargate_cpu
+    image_url          = data.terraform_remote_state.management.outputs.ecr_prometheus_url
+    memory             = var.fargate_memory
+    memory_reservation = ""
+    user               = "nobody"
+    ports              = jsonencode([var.prometheus_port])
+    ulimits            = jsonencode([])
+    log_group          = aws_cloudwatch_log_group.monitoring.name
+    region             = data.aws_region.current.name
+    config_bucket      = local.is_management_env ? data.terraform_remote_state.management.outputs.config_bucket.id : data.terraform_remote_state.common.outputs.config_bucket.id
 
     mount_points = jsonencode([
       {
@@ -64,17 +65,18 @@ data "template_file" "thanos_receiver_outofband_definition" {
   count    = local.is_management_env ? 1 : 0
   template = file("${path.module}/container_definition.tpl")
   vars = {
-    name          = "thanos-receiver"
-    group_name    = "thanos"
-    cpu           = var.fargate_cpu
-    image_url     = data.terraform_remote_state.management.outputs.ecr_thanos_url
-    memory        = var.fargate_memory
-    user          = "nobody"
-    ports         = jsonencode([var.thanos_port_grpc, var.thanos_port_remote_write])
-    ulimits       = jsonencode([])
-    log_group     = aws_cloudwatch_log_group.monitoring.name
-    region        = data.aws_region.current.name
-    config_bucket = local.is_management_env ? data.terraform_remote_state.management.outputs.config_bucket.id : data.terraform_remote_state.common.outputs.config_bucket.id
+    name               = "thanos-receiver"
+    group_name         = "thanos"
+    cpu                = var.fargate_cpu
+    image_url          = data.terraform_remote_state.management.outputs.ecr_thanos_url
+    memory             = ""
+    memory_reservation = var.fargate_memory
+    user               = "nobody"
+    ports              = jsonencode([var.thanos_port_grpc, var.thanos_port_remote_write])
+    ulimits            = jsonencode([])
+    log_group          = aws_cloudwatch_log_group.monitoring.name
+    region             = data.aws_region.current.name
+    config_bucket      = local.is_management_env ? data.terraform_remote_state.management.outputs.config_bucket.id : data.terraform_remote_state.common.outputs.config_bucket.id
 
     mount_points = jsonencode([
       {

--- a/prometheus_ecs.tf
+++ b/prometheus_ecs.tf
@@ -14,17 +14,18 @@ resource "aws_ecs_task_definition" "prometheus" {
 data "template_file" "prometheus_definition" {
   template = file("${path.module}/container_definition.tpl")
   vars = {
-    name          = "prometheus"
-    group_name    = "prometheus"
-    cpu           = var.fargate_cpu
-    image_url     = data.terraform_remote_state.management.outputs.ecr_prometheus_url
-    memory        = var.fargate_memory
-    user          = "nobody"
-    ports         = jsonencode([var.prometheus_port])
-    ulimits       = jsonencode([])
-    log_group     = aws_cloudwatch_log_group.monitoring.name
-    region        = data.aws_region.current.name
-    config_bucket = local.is_management_env ? data.terraform_remote_state.management.outputs.config_bucket.id : data.terraform_remote_state.common.outputs.config_bucket.id
+    name               = "prometheus"
+    group_name         = "prometheus"
+    cpu                = var.fargate_cpu
+    image_url          = data.terraform_remote_state.management.outputs.ecr_prometheus_url
+    memory             = var.fargate_memory
+    memory_reservation = ""
+    user               = "nobody"
+    ports              = jsonencode([var.prometheus_port])
+    ulimits            = jsonencode([])
+    log_group          = aws_cloudwatch_log_group.monitoring.name
+    region             = data.aws_region.current.name
+    config_bucket      = local.is_management_env ? data.terraform_remote_state.management.outputs.config_bucket.id : data.terraform_remote_state.common.outputs.config_bucket.id
 
     mount_points = jsonencode([])
 
@@ -40,17 +41,18 @@ data "template_file" "prometheus_definition" {
 data "template_file" "ecs_service_discovery_definition" {
   template = file("${path.module}/container_definition.tpl")
   vars = {
-    name          = "ecs-service-discovery"
-    group_name    = "ecs_service_discovery"
-    cpu           = var.fargate_cpu
-    image_url     = data.terraform_remote_state.management.outputs.ecr_ecs_service_discovery_url
-    memory        = var.fargate_memory
-    user          = "nobody"
-    ports         = jsonencode([])
-    ulimits       = jsonencode([])
-    log_group     = aws_cloudwatch_log_group.monitoring.name
-    region        = data.aws_region.current.name
-    config_bucket = local.is_management_env ? data.terraform_remote_state.management.outputs.config_bucket.id : data.terraform_remote_state.common.outputs.config_bucket.id
+    name               = "ecs-service-discovery"
+    group_name         = "ecs_service_discovery"
+    cpu                = var.fargate_cpu
+    image_url          = data.terraform_remote_state.management.outputs.ecr_ecs_service_discovery_url
+    memory             = var.fargate_memory
+    memory_reservation = ""
+    user               = "nobody"
+    ports              = jsonencode([])
+    ulimits            = jsonencode([])
+    log_group          = aws_cloudwatch_log_group.monitoring.name
+    region             = data.aws_region.current.name
+    config_bucket      = local.is_management_env ? data.terraform_remote_state.management.outputs.config_bucket.id : data.terraform_remote_state.common.outputs.config_bucket.id
 
     mount_points = jsonencode([])
 
@@ -70,17 +72,18 @@ data "template_file" "ecs_service_discovery_definition" {
 data "template_file" "thanos_receiver_prometheus_definition" {
   template = file("${path.module}/container_definition.tpl")
   vars = {
-    name          = "thanos-receiver"
-    group_name    = "thanos"
-    cpu           = var.receiver_cpu
-    image_url     = data.terraform_remote_state.management.outputs.ecr_thanos_url
-    memory        = var.receiver_memory
-    user          = "nobody"
-    ports         = jsonencode([var.thanos_port_grpc, var.thanos_port_remote_write])
-    ulimits       = jsonencode([])
-    log_group     = aws_cloudwatch_log_group.monitoring.name
-    region        = data.aws_region.current.name
-    config_bucket = local.is_management_env ? data.terraform_remote_state.management.outputs.config_bucket.id : data.terraform_remote_state.common.outputs.config_bucket.id
+    name               = "thanos-receiver"
+    group_name         = "thanos"
+    cpu                = var.fargate_cpu
+    image_url          = data.terraform_remote_state.management.outputs.ecr_thanos_url
+    memory             = ""
+    memory_reservation = var.fargate_memory
+    user               = "nobody"
+    ports              = jsonencode([var.thanos_port_grpc, var.thanos_port_remote_write])
+    ulimits            = jsonencode([])
+    log_group          = aws_cloudwatch_log_group.monitoring.name
+    region             = data.aws_region.current.name
+    config_bucket      = local.is_management_env ? data.terraform_remote_state.management.outputs.config_bucket.id : data.terraform_remote_state.common.outputs.config_bucket.id
 
     mount_points = jsonencode([])
 

--- a/reserved_container_definition.tpl
+++ b/reserved_container_definition.tpl
@@ -2,6 +2,7 @@
   "cpu": ${cpu},
   "image": "${image_url}",
   "memory": ${memory},
+  "memoryReservation": ${memory_reservation},
   "name": "${name}",
   "networkMode": "awsvpc",
   "user": "${user}",

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,14 @@ variable "fargate_memory" {
   default = "512"
 }
 
+variable "receiver_cpu" {
+  default = "512"
+}
+
+variable "receiver_memory" {
+  default = "1024"
+}
+
 variable "https_port" {
   default = 443
 }


### PR DESCRIPTION
We no longer need the EFS volume, as the receiver is streaming directly to S3.
The receiver however, is OOMing on startup, so I've double its resources.