### PR TITLE
bump store cpu, restore ci cycle jobs

### DIFF
--- a/ci/jobs/dev.yml
+++ b/ci/jobs/dev.yml
@@ -10,3 +10,9 @@ jobs:
       - .: (( inject meta.plan.terraform-apply ))
 
       - .: (( inject meta.plan.terraform-plan ))
+      - .: (( inject meta.plan.cycle-containers ))
+        task: trigger-prometheus-deployment
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
+          CLUSTER: main
+          SERVICE: prometheus

--- a/ci/jobs/integration.yml
+++ b/ci/jobs/integration.yml
@@ -18,3 +18,9 @@ jobs:
       - .: (( inject meta.plan.terraform-plan ))
         params:
           TF_WORKSPACE: integration
+      - .: (( inject meta.plan.cycle-containers ))
+        task: trigger-prometheus-deployment
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
+          CLUSTER: main
+          SERVICE: prometheus

--- a/ci/jobs/management.yml
+++ b/ci/jobs/management.yml
@@ -22,3 +22,16 @@ jobs:
       - .: (( inject meta.plan.terraform-plan ))
         params:
           TF_WORKSPACE: management
+      - .: (( inject meta.plan.cycle-containers ))
+        task: trigger-outofband-deployment
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.management)):role/ci
+          CLUSTER: main
+          SERVICE: outofband
+
+      - .: (( inject meta.plan.cycle-containers ))
+        task: trigger-prometheus-deployment
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.management)):role/ci
+          CLUSTER: main
+          SERVICE: prometheus

--- a/ci/jobs/management_dev.yml
+++ b/ci/jobs/management_dev.yml
@@ -17,3 +17,16 @@ jobs:
       - .: (( inject meta.plan.terraform-plan ))
         params:
           TF_WORKSPACE: management-dev
+      - .: (( inject meta.plan.cycle-containers ))
+        task: trigger-outofband-deployment
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.management-dev)):role/ci
+          CLUSTER: main
+          SERVICE: outofband
+
+      - .: (( inject meta.plan.cycle-containers ))
+        task: trigger-prometheus-deployment
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.management-dev)):role/ci
+          CLUSTER: main
+          SERVICE: prometheus

--- a/ci/jobs/preprod.yml
+++ b/ci/jobs/preprod.yml
@@ -18,3 +18,9 @@ jobs:
       - .: (( inject meta.plan.terraform-plan ))
         params:
           TF_WORKSPACE: preprod
+      - .: (( inject meta.plan.cycle-containers ))
+        task: trigger-prometheus-deployment
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
+          CLUSTER: main
+          SERVICE: prometheus

--- a/ci/jobs/production.yml
+++ b/ci/jobs/production.yml
@@ -18,3 +18,9 @@ jobs:
       - .: (( inject meta.plan.terraform-plan ))
         params:
           TF_WORKSPACE: production
+      - .: (( inject meta.plan.cycle-containers ))
+        task: trigger-prometheus-deployment
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
+          CLUSTER: main
+          SERVICE: prometheus

--- a/ci/jobs/qa.yml
+++ b/ci/jobs/qa.yml
@@ -18,3 +18,9 @@ jobs:
       - .: (( inject meta.plan.terraform-plan ))
         params:
           TF_WORKSPACE: qa
+      - .: (( inject meta.plan.cycle-containers ))
+        task: trigger-prometheus-deployment
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
+          CLUSTER: main
+          SERVICE: prometheus

--- a/thanos_store_ecs.tf
+++ b/thanos_store_ecs.tf
@@ -3,7 +3,7 @@ resource "aws_ecs_task_definition" "thanos_store" {
   family                   = "thanos-store"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = "512"
+  cpu                      = "1024"
   memory                   = "4096"
   task_role_arn            = aws_iam_role.thanos_store[local.primary_role_index].arn
   execution_role_arn       = local.is_management_env ? data.terraform_remote_state.management.outputs.ecs_task_execution_role.arn : data.terraform_remote_state.common.outputs.ecs_task_execution_role.arn


### PR DESCRIPTION
store is running at 100% CPU then seemingly falling over.
CI cycle jobs feel bad, but serve a purpose whilst we're investigating.