### PR TITLE
bump receive memory 50%, bump image versions

### DIFF
--- a/prometheus_ecs.tf
+++ b/prometheus_ecs.tf
@@ -40,7 +40,7 @@ data "template_file" "prometheus_definition" {
     group_name         = "prometheus"
     cpu                = var.fargate_cpu
     image_url          = format("%s:%s", data.terraform_remote_state.management.outputs.ecr_prometheus_url, var.image_versions.prometheus)
-    memory             = var.receiver_memory
+    memory             = var.ec2_memory
     memory_reservation = var.fargate_memory
     user               = "nobody"
     ports              = jsonencode([var.prometheus_port])
@@ -84,7 +84,7 @@ data "template_file" "ecs_service_discovery_definition" {
     group_name         = "ecs_service_discovery"
     cpu                = var.fargate_cpu
     image_url          = format("%s:%s", data.terraform_remote_state.management.outputs.ecr_ecs_service_discovery_url, var.image_versions.ecs-service-discovery)
-    memory             = var.receiver_memory
+    memory             = var.ec2_memory
     memory_reservation = var.fargate_memory
     user               = "nobody"
     ports              = jsonencode([])

--- a/variables.tf
+++ b/variables.tf
@@ -46,12 +46,16 @@ variable "fargate_memory" {
   default = "512"
 }
 
+variable "ec2_memory" {
+  default = "1024"
+}
+
 variable "receiver_cpu" {
   default = "512"
 }
 
 variable "receiver_memory" {
-  default = "1024"
+  default = "1536"
 }
 
 variable "store_cpu" {
@@ -122,8 +126,8 @@ variable "desired_capacity" {
 variable "image_versions" {
   description = "pinned image versions to use"
   default = {
-    prometheus            = "0.0.13"
-    thanos                = "0.0.21"
+    prometheus            = "0.0.14"
+    thanos                = "0.0.22"
     alertmanager          = "0.0.5"
     ecs-service-discovery = "0.0.3"
     grafana               = "0.0.11"


### PR DESCRIPTION
Receive is OOMing.  Bumped container mem cap 50% higher.  Reduced local storage retention to 3 days in Prometheus & Thanos to reduce strain.