### PR TITLE
Trigger rollouts on service updates

### DIFF
--- a/adg_pushgateway_ecs.tf
+++ b/adg_pushgateway_ecs.tf
@@ -46,6 +46,8 @@ resource "aws_ecs_service" "adg_pushgateway" {
   platform_version = var.platform_version
   desired_count    = 1
   launch_type      = "FARGATE"
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent = 200
 
   network_configuration {
     security_groups = [aws_security_group.adg_pushgateway[local.primary_role_index].id]

--- a/adg_pushgateway_ecs.tf
+++ b/adg_pushgateway_ecs.tf
@@ -39,15 +39,15 @@ data "template_file" "adg_pushgateway_definition" {
 }
 
 resource "aws_ecs_service" "adg_pushgateway" {
-  count            = local.is_management_env ? 0 : 1
-  name             = "adg-pushgateway"
-  cluster          = aws_ecs_cluster.metrics_ecs_cluster.id
-  task_definition  = aws_ecs_task_definition.adg_pushgateway[local.primary_role_index].arn
-  platform_version = var.platform_version
-  desired_count    = 1
-  launch_type      = "FARGATE"
+  count                              = local.is_management_env ? 0 : 1
+  name                               = "adg-pushgateway"
+  cluster                            = aws_ecs_cluster.metrics_ecs_cluster.id
+  task_definition                    = aws_ecs_task_definition.adg_pushgateway[local.primary_role_index].arn
+  platform_version                   = var.platform_version
+  desired_count                      = 1
+  launch_type                        = "FARGATE"
   deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent = 200
+  deployment_maximum_percent         = 200
 
   network_configuration {
     security_groups = [aws_security_group.adg_pushgateway[local.primary_role_index].id]

--- a/cloudwatch_exporter_ecs.tf
+++ b/cloudwatch_exporter_ecs.tf
@@ -47,6 +47,8 @@ resource "aws_ecs_service" "cloudwatch_exporter" {
   platform_version = var.platform_version
   desired_count    = 1
   launch_type      = "FARGATE"
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent = 200
 
   network_configuration {
     security_groups = [aws_security_group.cloudwatch_exporter.id, aws_security_group.monitoring_common[local.secondary_role_index].id]

--- a/cloudwatch_exporter_ecs.tf
+++ b/cloudwatch_exporter_ecs.tf
@@ -41,14 +41,14 @@ data "template_file" "cloudwatch_exporter_definition" {
 }
 
 resource "aws_ecs_service" "cloudwatch_exporter" {
-  name             = "cloudwatch-exporter"
-  cluster          = aws_ecs_cluster.metrics_ecs_cluster.id
-  task_definition  = aws_ecs_task_definition.cloudwatch_exporter.arn
-  platform_version = var.platform_version
-  desired_count    = 1
-  launch_type      = "FARGATE"
+  name                               = "cloudwatch-exporter"
+  cluster                            = aws_ecs_cluster.metrics_ecs_cluster.id
+  task_definition                    = aws_ecs_task_definition.cloudwatch_exporter.arn
+  platform_version                   = var.platform_version
+  desired_count                      = 1
+  launch_type                        = "FARGATE"
   deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent = 200
+  deployment_maximum_percent         = 200
 
   network_configuration {
     security_groups = [aws_security_group.cloudwatch_exporter.id, aws_security_group.monitoring_common[local.secondary_role_index].id]

--- a/cluster_ecs.tf
+++ b/cluster_ecs.tf
@@ -208,7 +208,7 @@ resource "aws_autoscaling_group" "mgmt_metrics_cluster" {
   instance_refresh {
     strategy = "Rolling"
     preferences {
-      min_healthy_percentage = 50
+      min_healthy_percentage = 25
     }
   }
 

--- a/grafana_ecs.tf
+++ b/grafana_ecs.tf
@@ -94,15 +94,15 @@ data "template_file" "grafana_sidecar_definition" {
 }
 
 resource "aws_ecs_service" "grafana" {
-  count            = local.is_management_env ? 1 : 0
-  name             = "grafana"
-  cluster          = aws_ecs_cluster.metrics_ecs_cluster.id
-  task_definition  = aws_ecs_task_definition.grafana[local.primary_role_index].arn
-  platform_version = var.platform_version
-  desired_count    = 1
-  launch_type      = "FARGATE"
+  count                              = local.is_management_env ? 1 : 0
+  name                               = "grafana"
+  cluster                            = aws_ecs_cluster.metrics_ecs_cluster.id
+  task_definition                    = aws_ecs_task_definition.grafana[local.primary_role_index].arn
+  platform_version                   = var.platform_version
+  desired_count                      = 1
+  launch_type                        = "FARGATE"
   deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent = 200
+  deployment_maximum_percent         = 200
 
   network_configuration {
     security_groups = [aws_security_group.grafana[0].id, aws_security_group.monitoring_common[local.primary_role_index].id]

--- a/grafana_ecs.tf
+++ b/grafana_ecs.tf
@@ -101,6 +101,8 @@ resource "aws_ecs_service" "grafana" {
   platform_version = var.platform_version
   desired_count    = 1
   launch_type      = "FARGATE"
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent = 200
 
   network_configuration {
     security_groups = [aws_security_group.grafana[0].id, aws_security_group.monitoring_common[local.primary_role_index].id]

--- a/hbase_exporter_ecs.tf
+++ b/hbase_exporter_ecs.tf
@@ -54,6 +54,8 @@ resource "aws_ecs_service" "hbase_exporter" {
   platform_version = var.platform_version
   desired_count    = 1
   launch_type      = "FARGATE"
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent = 200
 
   network_configuration {
     security_groups = [aws_security_group.hbase_exporter[local.secondary_role_index].id, aws_security_group.monitoring_common[local.secondary_role_index].id]

--- a/hbase_exporter_ecs.tf
+++ b/hbase_exporter_ecs.tf
@@ -47,15 +47,15 @@ data "template_file" "hbase_exporter_definition" {
 }
 
 resource "aws_ecs_service" "hbase_exporter" {
-  count            = local.is_management_env ? 0 : 1
-  name             = "hbase-exporter"
-  cluster          = aws_ecs_cluster.metrics_ecs_cluster.id
-  task_definition  = aws_ecs_task_definition.hbase_exporter[local.secondary_role_index].arn
-  platform_version = var.platform_version
-  desired_count    = 1
-  launch_type      = "FARGATE"
+  count                              = local.is_management_env ? 0 : 1
+  name                               = "hbase-exporter"
+  cluster                            = aws_ecs_cluster.metrics_ecs_cluster.id
+  task_definition                    = aws_ecs_task_definition.hbase_exporter[local.secondary_role_index].arn
+  platform_version                   = var.platform_version
+  desired_count                      = 1
+  launch_type                        = "FARGATE"
   deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent = 200
+  deployment_maximum_percent         = 200
 
   network_configuration {
     security_groups = [aws_security_group.hbase_exporter[local.secondary_role_index].id, aws_security_group.monitoring_common[local.secondary_role_index].id]

--- a/outofband_ecs.tf
+++ b/outofband_ecs.tf
@@ -120,15 +120,15 @@ data "template_file" "thanos_receiver_outofband_definition" {
 }
 
 resource "aws_ecs_service" "outofband" {
-  count                = local.is_management_env ? 1 : 0
-  name                 = "outofband"
-  cluster              = aws_ecs_cluster.metrics_ecs_cluster.id
-  task_definition      = aws_ecs_task_definition.outofband[local.primary_role_index].arn
-  desired_count        = 3
-  launch_type          = "EC2"
-  force_new_deployment = true
+  count                              = local.is_management_env ? 1 : 0
+  name                               = "outofband"
+  cluster                            = aws_ecs_cluster.metrics_ecs_cluster.id
+  task_definition                    = aws_ecs_task_definition.outofband[local.primary_role_index].arn
+  desired_count                      = 3
+  launch_type                        = "EC2"
+  force_new_deployment               = true
   deployment_minimum_healthy_percent = 75
-  deployment_maximum_percent = 125
+  deployment_maximum_percent         = 125
 
   network_configuration {
     security_groups = [aws_security_group.outofband[local.primary_role_index].id, aws_security_group.monitoring_common[local.primary_role_index].id]

--- a/outofband_ecs.tf
+++ b/outofband_ecs.tf
@@ -127,6 +127,8 @@ resource "aws_ecs_service" "outofband" {
   desired_count        = 3
   launch_type          = "EC2"
   force_new_deployment = true
+  deployment_minimum_healthy_percent = 75
+  deployment_maximum_percent = 125
 
   network_configuration {
     security_groups = [aws_security_group.outofband[local.primary_role_index].id, aws_security_group.monitoring_common[local.primary_role_index].id]

--- a/pdm_exporter_ecs.tf
+++ b/pdm_exporter_ecs.tf
@@ -54,6 +54,8 @@ resource "aws_ecs_service" "pdm_exporter" {
   platform_version = var.platform_version
   desired_count    = 1
   launch_type      = "FARGATE"
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent = 200
 
   network_configuration {
     security_groups = [aws_security_group.pdm_exporter[local.primary_role_index].id, aws_security_group.monitoring_common[local.secondary_role_index].id]

--- a/pdm_exporter_ecs.tf
+++ b/pdm_exporter_ecs.tf
@@ -47,15 +47,15 @@ data "template_file" "pdm_exporter_definition" {
 }
 
 resource "aws_ecs_service" "pdm_exporter" {
-  count            = local.is_management_env ? 0 : 1
-  name             = "pdm-exporter"
-  cluster          = aws_ecs_cluster.metrics_ecs_cluster.id
-  task_definition  = aws_ecs_task_definition.pdm_exporter[local.primary_role_index].arn
-  platform_version = var.platform_version
-  desired_count    = 1
-  launch_type      = "FARGATE"
+  count                              = local.is_management_env ? 0 : 1
+  name                               = "pdm-exporter"
+  cluster                            = aws_ecs_cluster.metrics_ecs_cluster.id
+  task_definition                    = aws_ecs_task_definition.pdm_exporter[local.primary_role_index].arn
+  platform_version                   = var.platform_version
+  desired_count                      = 1
+  launch_type                        = "FARGATE"
   deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent = 200
+  deployment_maximum_percent         = 200
 
   network_configuration {
     security_groups = [aws_security_group.pdm_exporter[local.primary_role_index].id, aws_security_group.monitoring_common[local.secondary_role_index].id]

--- a/prometheus_ecs.tf
+++ b/prometheus_ecs.tf
@@ -168,6 +168,8 @@ resource "aws_ecs_service" "prometheus" {
   desired_count        = 3
   launch_type          = "EC2"
   force_new_deployment = true
+  deployment_minimum_healthy_percent = 75
+  deployment_maximum_percent = 125
 
   network_configuration {
     security_groups = [aws_security_group.prometheus.id, aws_security_group.monitoring_common[local.secondary_role_index].id]

--- a/prometheus_ecs.tf
+++ b/prometheus_ecs.tf
@@ -162,14 +162,14 @@ data "template_file" "thanos_receiver_prometheus_definition" {
 }
 
 resource "aws_ecs_service" "prometheus" {
-  name                 = "prometheus"
-  cluster              = aws_ecs_cluster.metrics_ecs_cluster.id
-  task_definition      = aws_ecs_task_definition.prometheus.arn
-  desired_count        = 3
-  launch_type          = "EC2"
-  force_new_deployment = true
+  name                               = "prometheus"
+  cluster                            = aws_ecs_cluster.metrics_ecs_cluster.id
+  task_definition                    = aws_ecs_task_definition.prometheus.arn
+  desired_count                      = 3
+  launch_type                        = "EC2"
+  force_new_deployment               = true
   deployment_minimum_healthy_percent = 75
-  deployment_maximum_percent = 125
+  deployment_maximum_percent         = 125
 
   network_configuration {
     security_groups = [aws_security_group.prometheus.id, aws_security_group.monitoring_common[local.secondary_role_index].id]

--- a/thanos_query_ecs.tf
+++ b/thanos_query_ecs.tf
@@ -47,16 +47,16 @@ data "template_file" "thanos_query_definition" {
 }
 
 resource "aws_ecs_service" "thanos_query" {
-  count                = local.is_management_env ? 1 : 0
-  name                 = "thanos-query"
-  cluster              = aws_ecs_cluster.metrics_ecs_cluster.id
-  task_definition      = aws_ecs_task_definition.thanos_query[local.primary_role_index].arn
-  platform_version     = var.platform_version
-  desired_count        = 1
-  launch_type          = "FARGATE"
-  force_new_deployment = true
+  count                              = local.is_management_env ? 1 : 0
+  name                               = "thanos-query"
+  cluster                            = aws_ecs_cluster.metrics_ecs_cluster.id
+  task_definition                    = aws_ecs_task_definition.thanos_query[local.primary_role_index].arn
+  platform_version                   = var.platform_version
+  desired_count                      = 1
+  launch_type                        = "FARGATE"
+  force_new_deployment               = true
   deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent = 200
+  deployment_maximum_percent         = 200
 
   network_configuration {
     security_groups = [aws_security_group.thanos_query[0].id, aws_security_group.monitoring_common[local.primary_role_index].id]

--- a/thanos_query_ecs.tf
+++ b/thanos_query_ecs.tf
@@ -55,6 +55,8 @@ resource "aws_ecs_service" "thanos_query" {
   desired_count        = 1
   launch_type          = "FARGATE"
   force_new_deployment = true
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent = 200
 
   network_configuration {
     security_groups = [aws_security_group.thanos_query[0].id, aws_security_group.monitoring_common[local.primary_role_index].id]

--- a/thanos_ruler_ecs.tf
+++ b/thanos_ruler_ecs.tf
@@ -59,6 +59,8 @@ resource "aws_ecs_service" "thanos_ruler" {
   desired_count        = 1
   launch_type          = "FARGATE"
   force_new_deployment = true
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent = 200
 
   network_configuration {
     security_groups = [aws_security_group.thanos_ruler[0].id, aws_security_group.monitoring_common[local.primary_role_index].id]

--- a/thanos_ruler_ecs.tf
+++ b/thanos_ruler_ecs.tf
@@ -51,16 +51,16 @@ data "template_file" "thanos_ruler_definition" {
 }
 
 resource "aws_ecs_service" "thanos_ruler" {
-  count                = local.is_management_env ? 1 : 0
-  name                 = "thanos-ruler"
-  cluster              = aws_ecs_cluster.metrics_ecs_cluster.id
-  task_definition      = aws_ecs_task_definition.thanos_ruler[local.primary_role_index].arn
-  platform_version     = var.platform_version
-  desired_count        = 1
-  launch_type          = "FARGATE"
-  force_new_deployment = true
+  count                              = local.is_management_env ? 1 : 0
+  name                               = "thanos-ruler"
+  cluster                            = aws_ecs_cluster.metrics_ecs_cluster.id
+  task_definition                    = aws_ecs_task_definition.thanos_ruler[local.primary_role_index].arn
+  platform_version                   = var.platform_version
+  desired_count                      = 1
+  launch_type                        = "FARGATE"
+  force_new_deployment               = true
   deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent = 200
+  deployment_maximum_percent         = 200
 
   network_configuration {
     security_groups = [aws_security_group.thanos_ruler[0].id, aws_security_group.monitoring_common[local.primary_role_index].id]

--- a/thanos_store_ecs.tf
+++ b/thanos_store_ecs.tf
@@ -51,6 +51,8 @@ resource "aws_ecs_service" "thanos_store" {
   desired_count        = 1
   launch_type          = "FARGATE"
   force_new_deployment = true
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent = 200
 
   network_configuration {
     security_groups = [aws_security_group.thanos_store[0].id, aws_security_group.monitoring_common[local.primary_role_index].id]

--- a/thanos_store_ecs.tf
+++ b/thanos_store_ecs.tf
@@ -43,16 +43,16 @@ data "template_file" "thanos_store_definition" {
 }
 
 resource "aws_ecs_service" "thanos_store" {
-  count                = local.is_management_env ? 1 : 0
-  name                 = "thanos-store"
-  cluster              = aws_ecs_cluster.metrics_ecs_cluster.id
-  task_definition      = aws_ecs_task_definition.thanos_store[local.primary_role_index].arn
-  platform_version     = var.platform_version
-  desired_count        = 1
-  launch_type          = "FARGATE"
-  force_new_deployment = true
+  count                              = local.is_management_env ? 1 : 0
+  name                               = "thanos-store"
+  cluster                            = aws_ecs_cluster.metrics_ecs_cluster.id
+  task_definition                    = aws_ecs_task_definition.thanos_store[local.primary_role_index].arn
+  platform_version                   = var.platform_version
+  desired_count                      = 1
+  launch_type                        = "FARGATE"
+  force_new_deployment               = true
   deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent = 200
+  deployment_maximum_percent         = 200
 
   network_configuration {
     security_groups = [aws_security_group.thanos_store[0].id, aws_security_group.monitoring_common[local.primary_role_index].id]


### PR DESCRIPTION
Allows the service to scale the containers when changed.  This intends to apply against Task changes, and remove the `[INACTIVE]` issue we keep seeing.
Fargate instances can be scaled up before removing the old task, but EC2 based containers will need to scale down a little bit due to resource management.