### PR TITLE
balancing ec2 size and task quotas to achieve rollouts

### DIFF
--- a/outofband_ecs.tf
+++ b/outofband_ecs.tf
@@ -3,8 +3,8 @@ resource "aws_ecs_task_definition" "outofband" {
   family                   = "outofband"
   network_mode             = "awsvpc"
   requires_compatibilities = ["EC2"]
-  cpu                      = "2048"
-  memory                   = "12288"
+  cpu                      = var.prometheus_task_cpu[local.environment]
+  memory                   = var.prometheus_task_memory[local.environment]
   task_role_arn            = aws_iam_role.outofband[local.primary_role_index].arn
   execution_role_arn       = local.is_management_env ? data.terraform_remote_state.management.outputs.ecs_task_execution_role.arn : data.terraform_remote_state.common.outputs.ecs_task_execution_role.arn
   container_definitions    = "[${data.template_file.outofband_definition[local.primary_role_index].rendered}, ${data.template_file.thanos_receiver_outofband_definition[local.primary_role_index].rendered}]"
@@ -39,10 +39,10 @@ data "template_file" "outofband_definition" {
   vars = {
     name               = "outofband"
     group_name         = "prometheus"
-    cpu                = var.fargate_cpu
+    cpu                = var.prometheus_cpu
     image_url          = format("%s:%s", data.terraform_remote_state.management.outputs.ecr_prometheus_url, var.image_versions.prometheus)
     memory             = var.prometheus_memory[local.environment]
-    memory_reservation = var.fargate_memory
+    memory_reservation = var.ec2_memory
     user               = "nobody"
     ports              = jsonencode([var.prometheus_port])
     ulimits            = jsonencode([])
@@ -80,10 +80,10 @@ data "template_file" "thanos_receiver_outofband_definition" {
   vars = {
     name               = "thanos-receiver"
     group_name         = "thanos"
-    cpu                = var.fargate_cpu
+    cpu                = var.receiver_cpu
     image_url          = format("%s:%s", data.terraform_remote_state.management.outputs.ecr_thanos_url, var.image_versions.thanos)
     memory             = var.receiver_memory[local.environment]
-    memory_reservation = var.fargate_memory
+    memory_reservation = var.ec2_memory
     user               = "nobody"
     ports              = jsonencode([var.thanos_port_grpc, var.thanos_port_remote_write])
     ulimits            = jsonencode([])
@@ -127,8 +127,8 @@ resource "aws_ecs_service" "outofband" {
   desired_count                      = 3
   launch_type                        = "EC2"
   force_new_deployment               = true
-  deployment_minimum_healthy_percent = 75
-  deployment_maximum_percent         = 125
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
 
   network_configuration {
     security_groups = [aws_security_group.outofband[local.primary_role_index].id, aws_security_group.monitoring_common[local.primary_role_index].id]

--- a/prometheus_ecs.tf
+++ b/prometheus_ecs.tf
@@ -2,8 +2,8 @@ resource "aws_ecs_task_definition" "prometheus" {
   family                   = "prometheus"
   network_mode             = "awsvpc"
   requires_compatibilities = ["EC2"]
-  cpu                      = "2048"
-  memory                   = "12288"
+  cpu                      = var.prometheus_task_cpu[local.environment]
+  memory                   = var.prometheus_task_memory[local.environment]
   task_role_arn            = aws_iam_role.prometheus.arn
   execution_role_arn       = local.is_management_env ? data.terraform_remote_state.management.outputs.ecs_task_execution_role.arn : data.terraform_remote_state.common.outputs.ecs_task_execution_role.arn
   container_definitions    = "[${data.template_file.prometheus_definition.rendered}, ${data.template_file.thanos_receiver_prometheus_definition.rendered}, ${data.template_file.ecs_service_discovery_definition.rendered}]"
@@ -38,10 +38,10 @@ data "template_file" "prometheus_definition" {
   vars = {
     name               = "prometheus"
     group_name         = "prometheus"
-    cpu                = var.fargate_cpu
+    cpu                = var.prometheus_cpu
     image_url          = format("%s:%s", data.terraform_remote_state.management.outputs.ecr_prometheus_url, var.image_versions.prometheus)
     memory             = var.prometheus_memory[local.environment]
-    memory_reservation = var.fargate_memory
+    memory_reservation = var.ec2_memory
     user               = "nobody"
     ports              = jsonencode([var.prometheus_port])
     ulimits            = jsonencode([])
@@ -118,10 +118,10 @@ data "template_file" "thanos_receiver_prometheus_definition" {
   vars = {
     name               = "thanos-receiver"
     group_name         = "thanos"
-    cpu                = var.fargate_cpu
+    cpu                = var.receiver_cpu
     image_url          = format("%s:%s", data.terraform_remote_state.management.outputs.ecr_thanos_url, var.image_versions.thanos)
     memory             = var.receiver_memory[local.environment]
-    memory_reservation = var.fargate_memory
+    memory_reservation = var.ec2_memory
     user               = "nobody"
     ports              = jsonencode([var.thanos_port_grpc, var.thanos_port_remote_write])
     ulimits            = jsonencode([])
@@ -168,8 +168,8 @@ resource "aws_ecs_service" "prometheus" {
   desired_count                      = 3
   launch_type                        = "EC2"
   force_new_deployment               = true
-  deployment_minimum_healthy_percent = 75
-  deployment_maximum_percent         = 125
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
 
   network_configuration {
     security_groups = [aws_security_group.prometheus.id, aws_security_group.monitoring_common[local.secondary_role_index].id]

--- a/variables.tf
+++ b/variables.tf
@@ -38,6 +38,30 @@ variable "platform_version" {
   default     = "1.4.0"
 }
 
+variable "prometheus_task_cpu" {
+  default = {
+    development    = "2048"
+    qa             = "2048"
+    integration    = "2048"
+    preprod        = "2048"
+    production     = "2048"
+    management     = "2048"
+    management-dev = "2048"
+  }
+}
+
+variable "prometheus_task_memory" {
+  default = {
+    development    = "4096"
+    qa             = "4096"
+    integration    = "4096"
+    preprod        = "4096"
+    production     = "8192"
+    management     = "8192"
+    management-dev = "4096"
+  }
+}
+
 variable "fargate_cpu" {
   default = "512"
 }
@@ -48,6 +72,10 @@ variable "fargate_memory" {
 
 variable "ec2_memory" {
   default = "1024"
+}
+
+variable "prometheus_cpu" {
+  default = "512"
 }
 
 variable "receiver_cpu" {


### PR DESCRIPTION
This aims to control task resources per env, as well as resource allocation per container per env.
The goal is to allow 200% of tasks to run when we create changes that incur a deployment rollout.  Any other task ratio causes the new deployment to fail, and a rollback to occur, which ends in `[INACTIVE]` task states.