### PR TITLE
resource adjustment, add label doc, filter EMR instances

### DIFF
--- a/config/prometheus/prometheus-slave.yml
+++ b/config/prometheus/prometheus-slave.yml
@@ -95,6 +95,11 @@ scrape_configs:
         port: 7101
         filters: []
     relabel_configs:
+      - source_labels: [__meta_ec2_tag_aws_elasticmapreduce_instance_group_role]
+        separator: ;
+        regex: "(MASTER|CORE)"
+        replacement: $1
+        action: keep
       - source_labels: [__meta_ec2_tag_Name]
         regex: (.*)
         target_label: instance
@@ -113,6 +118,11 @@ scrape_configs:
         port: 7103
         filters: []
     relabel_configs:
+      - source_labels: [__meta_ec2_tag_aws_elasticmapreduce_instance_group_role]
+        separator: ;
+        regex: "(MASTER|CORE)"
+        replacement: $1
+        action: keep
       - source_labels: [__meta_ec2_tag_Name]
         regex: (.*)
         target_label: instance
@@ -131,6 +141,11 @@ scrape_configs:
         port: 7105
         filters: []
     relabel_configs:
+      - source_labels: [__meta_ec2_tag_aws_elasticmapreduce_instance_group_role]
+        separator: ;
+        regex: "(MASTER|CORE)"
+        replacement: $1
+        action: keep
       - source_labels: [__meta_ec2_tag_Name]
         regex: (.*)
         target_label: instance
@@ -149,6 +164,11 @@ scrape_configs:
         port: 7107
         filters: []
     relabel_configs:
+      - source_labels: [__meta_ec2_tag_aws_elasticmapreduce_instance_group_role]
+        separator: ;
+        regex: "(MASTER|CORE)"
+        replacement: $1
+        action: keep
       - source_labels: [__meta_ec2_tag_Name]
         regex: (.*)
         target_label: instance

--- a/config/prometheus/prometheus-slave.yml
+++ b/config/prometheus/prometheus-slave.yml
@@ -96,8 +96,7 @@ scrape_configs:
         filters: []
     relabel_configs:
       - source_labels: [__meta_ec2_tag_aws_elasticmapreduce_instance_group_role]
-        separator: ;
-        regex: "(MASTER|CORE)"
+        regex: "MASTER|CORE"
         replacement: $1
         action: keep
       - source_labels: [__meta_ec2_tag_Name]
@@ -119,8 +118,7 @@ scrape_configs:
         filters: []
     relabel_configs:
       - source_labels: [__meta_ec2_tag_aws_elasticmapreduce_instance_group_role]
-        separator: ;
-        regex: "(MASTER|CORE)"
+        regex: "MASTER|CORE"
         replacement: $1
         action: keep
       - source_labels: [__meta_ec2_tag_Name]
@@ -142,8 +140,7 @@ scrape_configs:
         filters: []
     relabel_configs:
       - source_labels: [__meta_ec2_tag_aws_elasticmapreduce_instance_group_role]
-        separator: ;
-        regex: "(MASTER|CORE)"
+        regex: "MASTER|CORE"
         replacement: $1
         action: keep
       - source_labels: [__meta_ec2_tag_Name]
@@ -165,8 +162,7 @@ scrape_configs:
         filters: []
     relabel_configs:
       - source_labels: [__meta_ec2_tag_aws_elasticmapreduce_instance_group_role]
-        separator: ;
-        regex: "(MASTER|CORE)"
+        regex: "MASTER|CORE"
         replacement: $1
         action: keep
       - source_labels: [__meta_ec2_tag_Name]

--- a/docs/labeling.md
+++ b/docs/labeling.md
@@ -1,0 +1,22 @@
+# Labeling
+
+Labels are the preferred and more powerful way to filter targets when scraping.  The labels we should focus on using are tags, as that is something we are 100% in control of.
+
+Something as simple as:
+```
+  - source_labels: [__meta_ec2_tag_Name]
+    separator: ;
+    regex: Brian
+    replacement: $1
+    action: keep
+```
+
+Will drop targets for which regex does not match `Brian` as the tag value of tag key `Name`
+
+Some labels can be difficult to translate, and you can query the Prometheus API to return all known targets and their associated labels using from inside the Prometheus container:
+
+`curl http://localhost:9090/api/v1/targets | cat >> targets`
+
+Then search inside `targets` for the tag you wish to use as a label.  For instance the tag key of `aws:elasticmapreduce:instance-group-role` is formed as `__meta_ec2_tag_aws_elasticmapreduce_instance_group_role` in Prometheus.
+
+Using the above label allows us to filter against EMR instances, as they are the only instances with such a tag key.

--- a/outofband_ecs.tf
+++ b/outofband_ecs.tf
@@ -39,7 +39,7 @@ data "template_file" "outofband_definition" {
   vars = {
     name               = "outofband"
     group_name         = "prometheus"
-    cpu                = var.prometheus_cpu
+    cpu                = var.prometheus_cpu[local.environment]
     image_url          = format("%s:%s", data.terraform_remote_state.management.outputs.ecr_prometheus_url, var.image_versions.prometheus)
     memory             = var.prometheus_memory[local.environment]
     memory_reservation = var.ec2_memory
@@ -80,7 +80,7 @@ data "template_file" "thanos_receiver_outofband_definition" {
   vars = {
     name               = "thanos-receiver"
     group_name         = "thanos"
-    cpu                = var.receiver_cpu
+    cpu                = var.receiver_cpu[local.environment]
     image_url          = format("%s:%s", data.terraform_remote_state.management.outputs.ecr_thanos_url, var.image_versions.thanos)
     memory             = var.receiver_memory[local.environment]
     memory_reservation = var.ec2_memory
@@ -127,8 +127,8 @@ resource "aws_ecs_service" "outofband" {
   desired_count                      = 3
   launch_type                        = "EC2"
   force_new_deployment               = true
-  deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
 
   network_configuration {
     security_groups = [aws_security_group.outofband[local.primary_role_index].id, aws_security_group.monitoring_common[local.primary_role_index].id]

--- a/prometheus_ecs.tf
+++ b/prometheus_ecs.tf
@@ -38,7 +38,7 @@ data "template_file" "prometheus_definition" {
   vars = {
     name               = "prometheus"
     group_name         = "prometheus"
-    cpu                = var.prometheus_cpu
+    cpu                = var.prometheus_cpu[local.environment]
     image_url          = format("%s:%s", data.terraform_remote_state.management.outputs.ecr_prometheus_url, var.image_versions.prometheus)
     memory             = var.prometheus_memory[local.environment]
     memory_reservation = var.ec2_memory
@@ -118,7 +118,7 @@ data "template_file" "thanos_receiver_prometheus_definition" {
   vars = {
     name               = "thanos-receiver"
     group_name         = "thanos"
-    cpu                = var.receiver_cpu
+    cpu                = var.receiver_cpu[local.environment]
     image_url          = format("%s:%s", data.terraform_remote_state.management.outputs.ecr_thanos_url, var.image_versions.thanos)
     memory             = var.receiver_memory[local.environment]
     memory_reservation = var.ec2_memory
@@ -168,8 +168,8 @@ resource "aws_ecs_service" "prometheus" {
   desired_count                      = 3
   launch_type                        = "EC2"
   force_new_deployment               = true
-  deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
 
   network_configuration {
     security_groups = [aws_security_group.prometheus.id, aws_security_group.monitoring_common[local.secondary_role_index].id]

--- a/variables.tf
+++ b/variables.tf
@@ -40,13 +40,13 @@ variable "platform_version" {
 
 variable "prometheus_task_cpu" {
   default = {
-    development    = "2048"
-    qa             = "2048"
-    integration    = "2048"
-    preprod        = "2048"
+    development    = "1024"
+    qa             = "1024"
+    integration    = "1024"
+    preprod        = "1024"
     production     = "2048"
     management     = "2048"
-    management-dev = "2048"
+    management-dev = "1024"
   }
 }
 
@@ -75,11 +75,27 @@ variable "ec2_memory" {
 }
 
 variable "prometheus_cpu" {
-  default = "512"
+  default = {
+    development    = "256"
+    qa             = "256"
+    integration    = "256"
+    preprod        = "256"
+    production     = "512"
+    management     = "512"
+    management-dev = "256"
+  }
 }
 
 variable "receiver_cpu" {
-  default = "512"
+  default = {
+    development    = "256"
+    qa             = "256"
+    integration    = "256"
+    preprod        = "256"
+    production     = "512"
+    management     = "512"
+    management-dev = "256"
+  }
 }
 
 variable "receiver_memory" {
@@ -205,4 +221,3 @@ variable "ecs_hardened_ami_id" {
   type        = string
   default     = "ami-049bba1a08b31ff8e"
 }
-


### PR DESCRIPTION
massively reduce coverage of scrapes with label filters.
Had to adjust rollout schema to allow for reduction in resources(0/100).  
PR will follow to return previous values (100/200)