### PR TITLE
Cicd sg

### DIFF
--- a/config/prometheus/prometheus-slave.yml
+++ b/config/prometheus/prometheus-slave.yml
@@ -6,7 +6,7 @@ global:
   evaluation_interval: 1m
 
 scrape_configs:
-  - job_name: ci
+  - job_name: concourse-metrics
     honor_timestamps: true
     scrape_interval: 1m
     scrape_timeout: 10s
@@ -21,7 +21,7 @@ scrape_configs:
     relabel_configs:
       - source_labels: [__meta_ec2_tag_Name]
         separator: ;
-        regex: concourse-web
+        regex: ^ci-concourse-web-[a-z0-9]{8}$
         replacement: $1
         action: keep
       - source_labels: [__meta_ec2_tag_Name, __meta_ec2_availability_zone]
@@ -40,30 +40,6 @@ scrape_configs:
         action: replace
         target_label: __metrics_path__
         regex: (.+)
-  - job_name: concourse-worker
-    honor_timestamps: true
-    scrape_interval: 1m
-    scrape_timeout: 10s
-    metrics_path: /metrics
-    scheme: http
-    ec2_sd_configs:
-      - endpoint: ""
-        region: eu-west-2
-        refresh_interval: 1m
-        port: 9100
-        filters: []
-    relabel_configs:
-      - source_labels: [__meta_ec2_tag_Name]
-        separator: ;
-        regex: ^ci-concourse-worker-eu-west-2[abc]-[a-z0-9]{8}$
-        replacement: $1
-        action: keep
-      - source_labels: [__meta_ec2_tag_Name, __meta_ec2_availability_zone]
-        separator: ;
-        regex: (.*)
-        target_label: instance
-        replacement: $1
-        action: replace
   - job_name: node-exporter
     honor_timestamps: true
     scrape_interval: 1m

--- a/outofband_ecs.tf
+++ b/outofband_ecs.tf
@@ -47,6 +47,7 @@ data "template_file" "outofband_definition" {
     ports              = jsonencode([var.prometheus_port])
     ulimits            = jsonencode([])
     log_group          = aws_cloudwatch_log_group.monitoring_metrics.name
+    essential          = true
     region             = data.aws_region.current.name
     config_bucket      = local.is_management_env ? data.terraform_remote_state.management.outputs.config_bucket.id : data.terraform_remote_state.common.outputs.config_bucket.id
 
@@ -88,6 +89,7 @@ data "template_file" "thanos_receiver_outofband_definition" {
     ports              = jsonencode([var.thanos_port_grpc, var.thanos_port_remote_write])
     ulimits            = jsonencode([])
     log_group          = aws_cloudwatch_log_group.monitoring_metrics.name
+    essential          = true
     region             = data.aws_region.current.name
     config_bucket      = local.is_management_env ? data.terraform_remote_state.management.outputs.config_bucket.id : data.terraform_remote_state.common.outputs.config_bucket.id
 

--- a/peering_concourse.tf
+++ b/peering_concourse.tf
@@ -20,46 +20,68 @@ resource "aws_route" "prometheus_secondary_concourse" {
   vpc_peering_connection_id = aws_vpc_peering_connection.concourse[0].id
 }
 
-# resource "aws_security_group_rule" "concourse_allow_ingress_prometheus" {
-#   count                    = local.is_management_env ? 1 : 0
-#   description              = "Allow prometheus ${var.secondary} to access concourse metrics"
-#   type                     = "ingress"
-#   protocol                 = "tcp"
-#   from_port                = var.prometheus_port
-#   to_port                  = var.prometheus_port
-#   security_group_id        = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
-#   source_security_group_id = aws_security_group.prometheus.id
-# }
+resource "aws_security_group_rule" "concourse_allow_ingress_prometheus" {
+  count                    = local.is_management_env ? 1 : 0
+  description              = "Allow prometheus ${var.secondary} to access concourse metrics"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = var.prometheus_port
+  to_port                  = var.prometheus_port
+  security_group_id        = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
+  source_security_group_id = aws_security_group.prometheus.id
+}
 
-# resource "aws_security_group_rule" "prometheus_allow_egress_concourse" {
-#   count                    = local.is_management_env ? 1 : 0
-#   description              = "Allow prometheus ${var.secondary} to access concourse metrics"
-#   type                     = "egress"
-#   protocol                 = "tcp"
-#   from_port                = var.prometheus_port
-#   to_port                  = var.prometheus_port
-#   security_group_id        = aws_security_group.prometheus.id
-#   source_security_group_id = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
-# }
+resource "aws_security_group_rule" "prometheus_allow_egress_concourse" {
+  count                    = local.is_management_env ? 1 : 0
+  description              = "Allow prometheus ${var.secondary} to access concourse metrics"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = var.prometheus_port
+  to_port                  = var.prometheus_port
+  security_group_id        = aws_security_group.prometheus.id
+  source_security_group_id = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
+}
 
-# resource "aws_security_group_rule" "concourse_worker_node_allow_ingress_prometheus" {
-#   count                    = local.is_management_env ? 1 : 0
-#   description              = "Allow prometheus ${var.secondary} to access concourse worker node metrics"
-#   type                     = "ingress"
-#   protocol                 = "tcp"
-#   from_port                = 9100
-#   to_port                  = 9100
-#   security_group_id        = data.terraform_remote_state.aws_concourse.outputs.concourse_worker_sg
-#   source_security_group_id = aws_security_group.prometheus.id
-# }
+resource "aws_security_group_rule" "concourse_web_node_allow_ingress_prometheus" {
+  count                    = local.is_management_env ? 1 : 0
+  description              = "Allow prometheus ${var.secondary} to access concourse web node metrics"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 9100
+  to_port                  = 9100
+  security_group_id        = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
+  source_security_group_id = aws_security_group.prometheus.id
+}
 
-# resource "aws_security_group_rule" "prometheus_allow_egress_concourse_worker_node" {
-#   count                    = local.is_management_env ? 1 : 0
-#   description              = "Allow prometheus ${var.secondary} to access concourse worker node metrics"
-#   type                     = "egress"
-#   protocol                 = "tcp"
-#   from_port                = 9100
-#   to_port                  = 9100
-#   security_group_id        = aws_security_group.prometheus.id
-#   source_security_group_id = data.terraform_remote_state.aws_concourse.outputs.concourse_worker_sg
-# }
+resource "aws_security_group_rule" "prometheus_allow_egress_concourse_web_node" {
+  count                    = local.is_management_env ? 1 : 0
+  description              = "Allow prometheus ${var.secondary} to access concourse web node metrics"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = 9100
+  to_port                  = 9100
+  security_group_id        = aws_security_group.prometheus.id
+  source_security_group_id = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
+}
+
+resource "aws_security_group_rule" "concourse_worker_node_allow_ingress_prometheus" {
+  count                    = local.is_management_env ? 1 : 0
+  description              = "Allow prometheus ${var.secondary} to access concourse worker node metrics"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 9100
+  to_port                  = 9100
+  security_group_id        = data.terraform_remote_state.aws_concourse.outputs.concourse_worker_sg
+  source_security_group_id = aws_security_group.prometheus.id
+}
+
+resource "aws_security_group_rule" "prometheus_allow_egress_concourse_worker_node" {
+  count                    = local.is_management_env ? 1 : 0
+  description              = "Allow prometheus ${var.secondary} to access concourse worker node metrics"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = 9100
+  to_port                  = 9100
+  security_group_id        = aws_security_group.prometheus.id
+  source_security_group_id = data.terraform_remote_state.aws_concourse.outputs.concourse_worker_sg
+}

--- a/peering_concourse.tf
+++ b/peering_concourse.tf
@@ -20,46 +20,46 @@ resource "aws_route" "prometheus_secondary_concourse" {
   vpc_peering_connection_id = aws_vpc_peering_connection.concourse[0].id
 }
 
-resource "aws_security_group_rule" "concourse_allow_ingress_prometheus" {
-  count                    = local.is_management_env ? 1 : 0
-  description              = "Allow prometheus ${var.secondary} to access concourse metrics"
-  type                     = "ingress"
-  protocol                 = "tcp"
-  from_port                = var.prometheus_port
-  to_port                  = var.prometheus_port
-  security_group_id        = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
-  source_security_group_id = aws_security_group.prometheus.id
-}
+# resource "aws_security_group_rule" "concourse_allow_ingress_prometheus" {
+#   count                    = local.is_management_env ? 1 : 0
+#   description              = "Allow prometheus ${var.secondary} to access concourse metrics"
+#   type                     = "ingress"
+#   protocol                 = "tcp"
+#   from_port                = var.prometheus_port
+#   to_port                  = var.prometheus_port
+#   security_group_id        = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
+#   source_security_group_id = aws_security_group.prometheus.id
+# }
 
-resource "aws_security_group_rule" "prometheus_allow_egress_concourse" {
-  count                    = local.is_management_env ? 1 : 0
-  description              = "Allow prometheus ${var.secondary} to access concourse metrics"
-  type                     = "egress"
-  protocol                 = "tcp"
-  from_port                = var.prometheus_port
-  to_port                  = var.prometheus_port
-  security_group_id        = aws_security_group.prometheus.id
-  source_security_group_id = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
-}
+# resource "aws_security_group_rule" "prometheus_allow_egress_concourse" {
+#   count                    = local.is_management_env ? 1 : 0
+#   description              = "Allow prometheus ${var.secondary} to access concourse metrics"
+#   type                     = "egress"
+#   protocol                 = "tcp"
+#   from_port                = var.prometheus_port
+#   to_port                  = var.prometheus_port
+#   security_group_id        = aws_security_group.prometheus.id
+#   source_security_group_id = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
+# }
 
-resource "aws_security_group_rule" "concourse_worker_node_allow_ingress_prometheus" {
-  count                    = local.is_management_env ? 1 : 0
-  description              = "Allow prometheus ${var.secondary} to access concourse worker node metrics"
-  type                     = "ingress"
-  protocol                 = "tcp"
-  from_port                = 9100
-  to_port                  = 9100
-  security_group_id        = data.terraform_remote_state.aws_concourse.outputs.concourse_worker_sg
-  source_security_group_id = aws_security_group.prometheus.id
-}
+# resource "aws_security_group_rule" "concourse_worker_node_allow_ingress_prometheus" {
+#   count                    = local.is_management_env ? 1 : 0
+#   description              = "Allow prometheus ${var.secondary} to access concourse worker node metrics"
+#   type                     = "ingress"
+#   protocol                 = "tcp"
+#   from_port                = 9100
+#   to_port                  = 9100
+#   security_group_id        = data.terraform_remote_state.aws_concourse.outputs.concourse_worker_sg
+#   source_security_group_id = aws_security_group.prometheus.id
+# }
 
-resource "aws_security_group_rule" "prometheus_allow_egress_concourse_worker_node" {
-  count                    = local.is_management_env ? 1 : 0
-  description              = "Allow prometheus ${var.secondary} to access concourse worker node metrics"
-  type                     = "egress"
-  protocol                 = "tcp"
-  from_port                = 9100
-  to_port                  = 9100
-  security_group_id        = aws_security_group.prometheus.id
-  source_security_group_id = data.terraform_remote_state.aws_concourse.outputs.concourse_worker_sg
-}
+# resource "aws_security_group_rule" "prometheus_allow_egress_concourse_worker_node" {
+#   count                    = local.is_management_env ? 1 : 0
+#   description              = "Allow prometheus ${var.secondary} to access concourse worker node metrics"
+#   type                     = "egress"
+#   protocol                 = "tcp"
+#   from_port                = 9100
+#   to_port                  = 9100
+#   security_group_id        = aws_security_group.prometheus.id
+#   source_security_group_id = data.terraform_remote_state.aws_concourse.outputs.concourse_worker_sg
+# }

--- a/peering_concourse.tf
+++ b/peering_concourse.tf
@@ -42,27 +42,27 @@ resource "aws_security_group_rule" "prometheus_allow_egress_concourse" {
   source_security_group_id = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
 }
 
-resource "aws_security_group_rule" "concourse_web_node_allow_ingress_prometheus" {
-  count                    = local.is_management_env ? 1 : 0
-  description              = "Allow prometheus ${var.secondary} to access concourse web node metrics"
-  type                     = "ingress"
-  protocol                 = "tcp"
-  from_port                = 9100
-  to_port                  = 9100
-  security_group_id        = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
-  source_security_group_id = aws_security_group.prometheus.id
-}
+# resource "aws_security_group_rule" "concourse_web_node_allow_ingress_prometheus" {
+#   count                    = local.is_management_env ? 1 : 0
+#   description              = "Allow prometheus ${var.secondary} to access concourse web node metrics"
+#   type                     = "ingress"
+#   protocol                 = "tcp"
+#   from_port                = 9100
+#   to_port                  = 9100
+#   security_group_id        = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
+#   source_security_group_id = aws_security_group.prometheus.id
+# }
 
-resource "aws_security_group_rule" "prometheus_allow_egress_concourse_web_node" {
-  count                    = local.is_management_env ? 1 : 0
-  description              = "Allow prometheus ${var.secondary} to access concourse web node metrics"
-  type                     = "egress"
-  protocol                 = "tcp"
-  from_port                = 9100
-  to_port                  = 9100
-  security_group_id        = aws_security_group.prometheus.id
-  source_security_group_id = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
-}
+# resource "aws_security_group_rule" "prometheus_allow_egress_concourse_web_node" {
+#   count                    = local.is_management_env ? 1 : 0
+#   description              = "Allow prometheus ${var.secondary} to access concourse web node metrics"
+#   type                     = "egress"
+#   protocol                 = "tcp"
+#   from_port                = 9100
+#   to_port                  = 9100
+#   security_group_id        = aws_security_group.prometheus.id
+#   source_security_group_id = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
+# }
 
 resource "aws_security_group_rule" "concourse_worker_node_allow_ingress_prometheus" {
   count                    = local.is_management_env ? 1 : 0

--- a/peering_concourse.tf
+++ b/peering_concourse.tf
@@ -42,27 +42,27 @@ resource "aws_security_group_rule" "prometheus_allow_egress_concourse" {
   source_security_group_id = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
 }
 
-# resource "aws_security_group_rule" "concourse_web_node_allow_ingress_prometheus" {
-#   count                    = local.is_management_env ? 1 : 0
-#   description              = "Allow prometheus ${var.secondary} to access concourse web node metrics"
-#   type                     = "ingress"
-#   protocol                 = "tcp"
-#   from_port                = 9100
-#   to_port                  = 9100
-#   security_group_id        = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
-#   source_security_group_id = aws_security_group.prometheus.id
-# }
+resource "aws_security_group_rule" "concourse_web_node_allow_ingress_prometheus" {
+  count                    = local.is_management_env ? 1 : 0
+  description              = "Allow prometheus ${var.secondary} to access concourse web node metrics"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 9100
+  to_port                  = 9100
+  security_group_id        = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
+  source_security_group_id = aws_security_group.prometheus.id
+}
 
-# resource "aws_security_group_rule" "prometheus_allow_egress_concourse_web_node" {
-#   count                    = local.is_management_env ? 1 : 0
-#   description              = "Allow prometheus ${var.secondary} to access concourse web node metrics"
-#   type                     = "egress"
-#   protocol                 = "tcp"
-#   from_port                = 9100
-#   to_port                  = 9100
-#   security_group_id        = aws_security_group.prometheus.id
-#   source_security_group_id = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
-# }
+resource "aws_security_group_rule" "prometheus_allow_egress_concourse_web_node" {
+  count                    = local.is_management_env ? 1 : 0
+  description              = "Allow prometheus ${var.secondary} to access concourse web node metrics"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = 9100
+  to_port                  = 9100
+  security_group_id        = aws_security_group.prometheus.id
+  source_security_group_id = data.terraform_remote_state.aws_concourse.outputs.concourse_web_sg
+}
 
 resource "aws_security_group_rule" "concourse_worker_node_allow_ingress_prometheus" {
   count                    = local.is_management_env ? 1 : 0

--- a/prometheus_ecs.tf
+++ b/prometheus_ecs.tf
@@ -46,6 +46,7 @@ data "template_file" "prometheus_definition" {
     ports              = jsonencode([var.prometheus_port])
     ulimits            = jsonencode([])
     log_group          = aws_cloudwatch_log_group.monitoring_metrics.name
+    essential          = true
     region             = data.aws_region.current.name
     config_bucket      = local.is_management_env ? data.terraform_remote_state.management.outputs.config_bucket.id : data.terraform_remote_state.common.outputs.config_bucket.id
 
@@ -90,6 +91,7 @@ data "template_file" "ecs_service_discovery_definition" {
     ports              = jsonencode([])
     ulimits            = jsonencode([])
     log_group          = aws_cloudwatch_log_group.monitoring_metrics.name
+    essential          = false
     region             = data.aws_region.current.name
     config_bucket      = local.is_management_env ? data.terraform_remote_state.management.outputs.config_bucket.id : data.terraform_remote_state.common.outputs.config_bucket.id
 
@@ -126,6 +128,7 @@ data "template_file" "thanos_receiver_prometheus_definition" {
     ports              = jsonencode([var.thanos_port_grpc, var.thanos_port_remote_write])
     ulimits            = jsonencode([])
     log_group          = aws_cloudwatch_log_group.monitoring_metrics.name
+    essential          = true
     region             = data.aws_region.current.name
     config_bucket      = local.is_management_env ? data.terraform_remote_state.management.outputs.config_bucket.id : data.terraform_remote_state.common.outputs.config_bucket.id
 

--- a/reserved_container_definition.tpl
+++ b/reserved_container_definition.tpl
@@ -7,6 +7,7 @@
   "name": "${name}",
   "networkMode": "awsvpc",
   "user": "${user}",
+  "essential": ${essential},
   "portMappings": ${jsonencode([
     for port in jsondecode(ports) : {
       containerPort = port,


### PR DESCRIPTION
Fixes scrape config to account for new concourse hostnames, and restores Concourse metrics.
Removes unnecessary scrape job, (concourse-workers), as they are bundled with the wider job.
Adds SG to allow web nodes to be scraped by `node_exporter`