### PR TITLE
updated prometheus default http method to be post

### DIFF
--- a/config/grafana/provisioning/datasources/datasource.yaml
+++ b/config/grafana/provisioning/datasources/datasource.yaml
@@ -7,3 +7,4 @@ datasources:
     access: proxy
     url: http://${thanos_query_hostname}:9090
     editable: false
+    httpMethod: POST


### PR DESCRIPTION
This is to prevent 414 request-url too large errors. 