### PR TITLE
double resources for store

### DIFF
--- a/thanos_store_ecs.tf
+++ b/thanos_store_ecs.tf
@@ -17,7 +17,7 @@ data "template_file" "thanos_store_definition" {
   vars = {
     name          = "thanos-store"
     group_name    = "thanos"
-    cpu           = var.store_cpu
+    cpu           = var.store_cpu[local.environment]
     image_url     = format("%s:%s", data.terraform_remote_state.management.outputs.ecr_thanos_url, var.image_versions.thanos)
     memory        = var.store_memory[local.environment]
     user          = "nobody"

--- a/thanos_store_ecs.tf
+++ b/thanos_store_ecs.tf
@@ -3,7 +3,7 @@ resource "aws_ecs_task_definition" "thanos_store" {
   family                   = "thanos-store"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = "1024"
+  cpu                      = "2048"
   memory                   = "4096"
   task_role_arn            = aws_iam_role.thanos_store[local.primary_role_index].arn
   execution_role_arn       = local.is_management_env ? data.terraform_remote_state.management.outputs.ecs_task_execution_role.arn : data.terraform_remote_state.common.outputs.ecs_task_execution_role.arn
@@ -19,7 +19,7 @@ data "template_file" "thanos_store_definition" {
     group_name    = "thanos"
     cpu           = var.store_cpu
     image_url     = format("%s:%s", data.terraform_remote_state.management.outputs.ecr_thanos_url, var.image_versions.thanos)
-    memory        = var.thanos_store_task_memory[local.environment]
+    memory        = var.store_memory[local.environment]
     user          = "nobody"
     ports         = jsonencode([var.thanos_port_grpc])
     ulimits       = jsonencode([var.ulimits])

--- a/variables.tf
+++ b/variables.tf
@@ -62,10 +62,17 @@ variable "prometheus_task_memory" {
   }
 }
 
-variable "thanos_store_task_memory" {
+variable "store_cpu" {
   default = {
     management     = "2048"
-    management-dev = "512"
+    management-dev = "1024"
+  }
+}
+
+variable "store_memory" {
+  default = {
+    management     = "4096"
+    management-dev = "2048"
   }
 }
 
@@ -127,10 +134,6 @@ variable "prometheus_memory" {
     management     = "4096"
     management-dev = "2048"
   }
-}
-
-variable "store_cpu" {
-  default = "1024"
 }
 
 variable "https_port" {


### PR DESCRIPTION
* In management store is running OOM and 100% CPU usage.  Likely due to the new dashboards and the large queries we're sending its way.