### PR TITLE
Fix SGs for failing Pushgateways, add Pushgateway Doc

### DIFF
--- a/cluster_sg.tf
+++ b/cluster_sg.tf
@@ -63,6 +63,28 @@ resource "aws_security_group_rule" "allow_metrics_cluster_egress_hbase_exporter"
   source_security_group_id = aws_security_group.hbase_exporter[0].id
 }
 
+resource "aws_security_group_rule" "allow_192976_egress_htme_pushgateway" {
+  count                    = local.is_management_env ? 0 : 1
+  description              = "Allows metrics cluster to access HTME pushgateway"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = var.pushgateway_port
+  to_port                  = var.pushgateway_port
+  security_group_id        = aws_security_group.metrics_cluster.id
+  source_security_group_id = aws_security_group.htme_pushgateway[0].id
+}
+
+resource "aws_security_group_rule" "allow_metrics_cluster_egress_ingest_pushgateway" {
+  count                    = local.is_management_env ? 0 : 1
+  description              = "Allows metrics cluster to access SDX pushgateway"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = var.pushgateway_port
+  to_port                  = var.pushgateway_port
+  security_group_id        = aws_security_group.metrics_cluster.id
+  source_security_group_id = aws_security_group.ingest_pushgateway[0].id
+}
+
 resource "aws_security_group" "mgmt_metrics_cluster" {
   count       = local.is_management_env ? 1 : 0
   name        = "metrics_cluster"

--- a/cluster_sg.tf
+++ b/cluster_sg.tf
@@ -63,7 +63,7 @@ resource "aws_security_group_rule" "allow_metrics_cluster_egress_hbase_exporter"
   source_security_group_id = aws_security_group.hbase_exporter[0].id
 }
 
-resource "aws_security_group_rule" "allow_192976_egress_htme_pushgateway" {
+resource "aws_security_group_rule" "allow_metrics_cluster_egress_htme_pushgateway" {
   count                    = local.is_management_env ? 0 : 1
   description              = "Allows metrics cluster to access HTME pushgateway"
   type                     = "egress"

--- a/docs/pushgateway.md
+++ b/docs/pushgateway.md
@@ -1,0 +1,16 @@
+# Pushgateway
+
+We use pushgateways to collate metrics for our long and short running services.  By pushing metrics to a pushgateway, this allows us to have access to metrics even if the service producing them is down.  By default we request each service, as its last action pushes it's metrics so we are able to capture everything.
+
+# Creating a Pushgateway
+
+We commonly create a Pushgateway per service, as these can get very busy and it allows us to reduce noise, and filter queries per job when refining our metrics.
+
+Each pushgateway will need the following:
+
+- An ECS Terraform file, containing it's `task_definition`, `container_definition`, `ecs_service` and `dns` entries. [Example](../adg_pushgateway_ecs.tf)
+- An IAM Terraform file, defining what role to assume when running its task. [Example](../adg_pushgateway_iam.tf)
+- A Security Group Terraform file, defining its own `security_group` and it's attachments to the service it is going to recieve metrics from.  We manage this here, and not from the service itself. [Example](../adg_pushgateway_sg.tf)
+
+You will also need to add the above security group to the [cluster security groups](../cluster_sg.tf) in order for the cluster to have access to the Pushgateway container, as well as the [Prometheus security groups](../prometheus_sg.tf), for Prometheus itself can scrape the metrics from the Pushgateway.
+

--- a/prometheus_sg.tf
+++ b/prometheus_sg.tf
@@ -65,7 +65,7 @@ resource "aws_security_group_rule" "allow_prometheus_egress_hbase_exporter" {
 
 resource "aws_security_group_rule" "allow_prometheus_egress_htme_pushgateway" {
   count                    = local.is_management_env ? 0 : 1
-  description              = "Allows prometheus to access SDX pushgateway"
+  description              = "Allows prometheus to access HTME pushgateway"
   type                     = "egress"
   protocol                 = "tcp"
   from_port                = var.pushgateway_port

--- a/prometheus_sg.tf
+++ b/prometheus_sg.tf
@@ -62,3 +62,25 @@ resource "aws_security_group_rule" "allow_prometheus_egress_hbase_exporter" {
   security_group_id        = aws_security_group.prometheus.id
   source_security_group_id = aws_security_group.hbase_exporter[0].id
 }
+
+resource "aws_security_group_rule" "allow_prometheus_egress_htme_pushgateway" {
+  count                    = local.is_management_env ? 0 : 1
+  description              = "Allows prometheus to access SDX pushgateway"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = var.pushgateway_port
+  to_port                  = var.pushgateway_port
+  security_group_id        = aws_security_group.prometheus.id
+  source_security_group_id = aws_security_group.htme_pushgateway[0].id
+}
+
+resource "aws_security_group_rule" "allow_prometheus_egress_ingest_pushgateway" {
+  count                    = local.is_management_env ? 0 : 1
+  description              = "Allows prometheus to access SDX pushgateway"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = var.pushgateway_port
+  to_port                  = var.pushgateway_port
+  security_group_id        = aws_security_group.prometheus.id
+  source_security_group_id = aws_security_group.ingest_pushgateway[0].id
+}

--- a/prometheus_sg.tf
+++ b/prometheus_sg.tf
@@ -76,7 +76,7 @@ resource "aws_security_group_rule" "allow_prometheus_egress_htme_pushgateway" {
 
 resource "aws_security_group_rule" "allow_prometheus_egress_ingest_pushgateway" {
   count                    = local.is_management_env ? 0 : 1
-  description              = "Allows prometheus to access SDX pushgateway"
+  description              = "Allows prometheus to access ingest pushgateway"
   type                     = "egress"
   protocol                 = "tcp"
   from_port                = var.pushgateway_port


### PR DESCRIPTION
- Add SG for `htme` and `ingest` Pushgateways to the metrics cluster.
- Add SG for `htme` and `ingest` Pushgateways to Prometheus.
- Add Pushgateway documentation.