### PR TITLE
roll outs just never work

### DIFF
--- a/prometheus_ecs.tf
+++ b/prometheus_ecs.tf
@@ -171,8 +171,8 @@ resource "aws_ecs_service" "prometheus" {
   desired_count                      = 3
   launch_type                        = "EC2"
   force_new_deployment               = true
-  deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 66
+  deployment_maximum_percent         = 133
 
   network_configuration {
     security_groups = [aws_security_group.prometheus.id, aws_security_group.monitoring_common[local.secondary_role_index].id]


### PR DESCRIPTION
- Rollouts just don't work.
- Reducing minimum healthy requirement to allow 1/3 to be down.
- Reducing maximum deployment to only go one instance at a time.