### PR TITLE
repin ami

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -271,5 +271,5 @@ variable "metrics_ecs_cluster_ec2_size" {
 variable "ecs_hardened_ami_id" {
   description = "The AMI ID of the latest/pinned ECS Hardened AMI Image"
   type        = string
-  default     = "ami-049bba1a08b31ff8e"
+  default     = "ami-014a6060ae79e83df"
 }


### PR DESCRIPTION
Pins version to AMI with the latest ECS Agent.  This agent allows ECS Exec via the CLI.  Added direct debugging to containers running in ECS EC2 and Fargate.