### PR TITLE
Repin ami

### DIFF
--- a/adg_pushgateway_iam.tf
+++ b/adg_pushgateway_iam.tf
@@ -18,3 +18,32 @@ data "aws_iam_policy_document" "adg_pushgateway_assume_role" {
   }
 }
 
+resource "aws_iam_role_policy_attachment" "adg_pushgateway_ecs_exec" {
+  count      = local.is_management_env ? 0 : 1
+  role       = aws_iam_role.adg_pushgateway[local.primary_role_index].name
+  policy_arn = aws_iam_policy.adg_pushgateway_ecs_exec[local.primary_role_index].arn
+}
+
+resource "aws_iam_policy" "adg_pushgateway_ecs_exec" {
+  count       = local.is_management_env ? 0 : 1
+  name        = "ADGPushgatewayECSExecPolicy"
+  description = "Allow ADGPushgateway container to exec from cli"
+  policy      = data.aws_iam_policy_document.adg_pushgateway_ecs_exec.json
+}
+
+data "aws_iam_policy_document" "adg_pushgateway_ecs_exec" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/alertmanager_iam.tf
+++ b/alertmanager_iam.tf
@@ -68,3 +68,33 @@ data "aws_iam_policy_document" "alertmanager_read_config" {
     ]
   }
 }
+
+resource "aws_iam_role_policy_attachment" "alertmanager_ecs_exec" {
+  count      = local.is_management_env ? 1 : 0
+  role       = aws_iam_role.alertmanager[local.primary_role_index].name
+  policy_arn = aws_iam_policy.alertmanager_ecs_exec[local.primary_role_index].arn
+}
+
+resource "aws_iam_policy" "alertmanager_ecs_exec" {
+  count       = local.is_management_env ? 1 : 0
+  name        = "AlertmanagerECSExecPolicy"
+  description = "Allow Alertmanager container to exec from cli"
+  policy      = data.aws_iam_policy_document.alertmanager_ecs_exec.json
+}
+
+data "aws_iam_policy_document" "alertmanager_ecs_exec" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/cloudwatch_exporter_iam.tf
+++ b/cloudwatch_exporter_iam.tf
@@ -95,8 +95,8 @@ data "aws_iam_policy_document" "cloudwatch_exporter_read_cloudwatch" {
 }
 
 resource "aws_iam_role_policy_attachment" "cloudwatch_exporter_ecs_exec" {
-  role       = aws_iam_role.cloudwatch_exporter[local.primary_role_index].name
-  policy_arn = aws_iam_policy.cloudwatch_exporter_ecs_exec[local.primary_role_index].arn
+  role       = aws_iam_role.cloudwatch_exporter.name
+  policy_arn = aws_iam_policy.cloudwatch_exporter_ecs_exec.arn
 }
 
 resource "aws_iam_policy" "cloudwatch_exporter_ecs_exec" {

--- a/cloudwatch_exporter_iam.tf
+++ b/cloudwatch_exporter_iam.tf
@@ -93,3 +93,31 @@ data "aws_iam_policy_document" "cloudwatch_exporter_read_cloudwatch" {
     ]
   }
 }
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_exporter_ecs_exec" {
+  role       = aws_iam_role.cloudwatch_exporter[local.primary_role_index].name
+  policy_arn = aws_iam_policy.cloudwatch_exporter_ecs_exec[local.primary_role_index].arn
+}
+
+resource "aws_iam_policy" "cloudwatch_exporter_ecs_exec" {
+  name        = "CloudwatchExporterECSExecPolicy"
+  description = "Allow CloudwatchExporter container to exec from cli"
+  policy      = data.aws_iam_policy_document.cloudwatch_exporter_ecs_exec.json
+}
+
+data "aws_iam_policy_document" "cloudwatch_exporter_ecs_exec" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/container_definition.tpl
+++ b/container_definition.tpl
@@ -6,6 +6,9 @@
   "name": "${name}",
   "networkMode": "awsvpc",
   "user": "${user}",
+  "linuxParameters": {
+    "initProcessEnabled": true
+  }
   "portMappings": ${jsonencode([
     for port in jsondecode(ports) : {
       containerPort = port,

--- a/container_definition.tpl
+++ b/container_definition.tpl
@@ -8,7 +8,7 @@
   "user": "${user}",
   "linuxParameters": {
     "initProcessEnabled": true
-  }
+  },
   "portMappings": ${jsonencode([
     for port in jsondecode(ports) : {
       containerPort = port,

--- a/grafana_container_definition.tpl
+++ b/grafana_container_definition.tpl
@@ -9,7 +9,7 @@
   "essential": ${essential},
   "linuxParameters": {
     "initProcessEnabled": true
-  }
+  },
   "entryPoint": ["/bin/sh", "-c", "echo '${entrypoint}' | base64 -d | sh;"],
   "portMappings": ${jsonencode([
     for port in jsondecode(ports) : {

--- a/grafana_container_definition.tpl
+++ b/grafana_container_definition.tpl
@@ -7,6 +7,9 @@
   "networkMode": "awsvpc",
   "user": "${user}",
   "essential": ${essential},
+  "linuxParameters": {
+    "initProcessEnabled": true
+  }
   "entryPoint": ["/bin/sh", "-c", "echo '${entrypoint}' | base64 -d | sh;"],
   "portMappings": ${jsonencode([
     for port in jsondecode(ports) : {

--- a/grafana_iam.tf
+++ b/grafana_iam.tf
@@ -100,3 +100,33 @@ data "aws_iam_policy_document" "grafana_read_secret" {
     ]
   }
 }
+
+resource "aws_iam_role_policy_attachment" "grafana_ecs_exec" {
+  count      = local.is_management_env ? 1 : 0
+  role       = aws_iam_role.grafana[local.primary_role_index].name
+  policy_arn = aws_iam_policy.grafana_ecs_exec[local.primary_role_index].arn
+}
+
+resource "aws_iam_policy" "grafana_ecs_exec" {
+  count       = local.is_management_env ? 1 : 0
+  name        = "GrafanaECSExecPolicy"
+  description = "Allow Grafana container to exec from cli"
+  policy      = data.aws_iam_policy_document.grafana_ecs_exec.json
+}
+
+data "aws_iam_policy_document" "grafana_ecs_exec" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/hbase_exporter_iam.tf
+++ b/hbase_exporter_iam.tf
@@ -99,3 +99,33 @@ data "aws_iam_policy_document" "hbase_exporter_read_metrics" {
     ]
   }
 }
+
+resource "aws_iam_role_policy_attachment" "hbase_exporter_ecs_exec" {
+  count      = local.is_management_env ? 0 : 1
+  role       = aws_iam_role.hbase_exporter[local.primary_role_index].name
+  policy_arn = aws_iam_policy.hbase_exporter_ecs_exec[local.primary_role_index].arn
+}
+
+resource "aws_iam_policy" "hbase_exporter_ecs_exec" {
+  count       = local.is_management_env ? 0 : 1
+  name        = "HbaseExporterECSExecPolicy"
+  description = "Allow HbaseExporter container to exec from cli"
+  policy      = data.aws_iam_policy_document.hbase_exporter_ecs_exec.json
+}
+
+data "aws_iam_policy_document" "hbase_exporter_ecs_exec" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/htme_pushgateway_iam.tf
+++ b/htme_pushgateway_iam.tf
@@ -18,3 +18,32 @@ data "aws_iam_policy_document" "htme_pushgateway_assume_role" {
   }
 }
 
+resource "aws_iam_role_policy_attachment" "htme_pushgateway_ecs_exec" {
+  count      = local.is_management_env ? 0 : 1
+  role       = aws_iam_role.htme_pushgateway[local.primary_role_index].name
+  policy_arn = aws_iam_policy.htme_pushgateway_ecs_exec[local.primary_role_index].arn
+}
+
+resource "aws_iam_policy" "htme_pushgateway_ecs_exec" {
+  count       = local.is_management_env ? 0 : 1
+  name        = "HTMEPushgatewayECSExecPolicy"
+  description = "Allow HTMEPushgateway container to exec from cli"
+  policy      = data.aws_iam_policy_document.htme_pushgateway_ecs_exec.json
+}
+
+data "aws_iam_policy_document" "htme_pushgateway_ecs_exec" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/ingest_pushgateway_iam.tf
+++ b/ingest_pushgateway_iam.tf
@@ -18,3 +18,32 @@ data "aws_iam_policy_document" "ingest_pushgateway_assume_role" {
   }
 }
 
+resource "aws_iam_role_policy_attachment" "ingest_pushgateway_ecs_exec" {
+  count      = local.is_management_env ? 0 : 1
+  role       = aws_iam_role.ingest_pushgateway[local.primary_role_index].name
+  policy_arn = aws_iam_policy.ingest_pushgateway_ecs_exec[local.primary_role_index].arn
+}
+
+resource "aws_iam_policy" "ingest_pushgateway_ecs_exec" {
+  count       = local.is_management_env ? 0 : 1
+  name        = "IngestPushgatewayECSExecPolicy"
+  description = "Allow IngestPushgateway container to exec from cli"
+  policy      = data.aws_iam_policy_document.ingest_pushgateway_ecs_exec.json
+}
+
+data "aws_iam_policy_document" "ingest_pushgateway_ecs_exec" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/outofband_iam.tf
+++ b/outofband_iam.tf
@@ -76,3 +76,32 @@ resource "aws_iam_role_policy_attachment" "outofband_monitoring_bucket_read_writ
   policy_arn = aws_iam_policy.monitoring_bucket_read_write.arn
 }
 
+resource "aws_iam_role_policy_attachment" "outofband_ecs_exec" {
+  count      = local.is_management_env ? 1 : 0
+  role       = aws_iam_role.outofband[local.primary_role_index].name
+  policy_arn = aws_iam_policy.outofband_ecs_exec[local.primary_role_index].arn
+}
+
+resource "aws_iam_policy" "outofband_ecs_exec" {
+  count       = local.is_management_env ? 1 : 0
+  name        = "OutofbandECSExecPolicy"
+  description = "Allow Outofband container to exec from cli"
+  policy      = data.aws_iam_policy_document.outofband_ecs_exec.json
+}
+
+data "aws_iam_policy_document" "outofband_ecs_exec" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/pdm_exporter_iam.tf
+++ b/pdm_exporter_iam.tf
@@ -122,3 +122,33 @@ data "aws_iam_policy_document" "pdm_exporter_read_metrics" {
     ]
   }
 }
+
+resource "aws_iam_role_policy_attachment" "pdm_exporter_ecs_exec" {
+  count      = local.is_management_env ? 0 : 1
+  role       = aws_iam_role.pdm_exporter[local.primary_role_index].name
+  policy_arn = aws_iam_policy.pdm_exporter_ecs_exec[local.primary_role_index].arn
+}
+
+resource "aws_iam_policy" "pdm_exporter_ecs_exec" {
+  count       = local.is_management_env ? 0 : 1
+  name        = "PDMExporterECSExecPolicy"
+  description = "Allow PDMExporter container to exec from cli"
+  policy      = data.aws_iam_policy_document.pdm_exporter_ecs_exec.json
+}
+
+data "aws_iam_policy_document" "pdm_exporter_ecs_exec" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/prometheus_iam.tf
+++ b/prometheus_iam.tf
@@ -163,13 +163,11 @@ data "aws_iam_policy_document" "monitoring_bucket_read_write" {
 }
 
 resource "aws_iam_role_policy_attachment" "prometheus_ecs_exec" {
-  count      = local.is_management_env ? 1 : 0
-  role       = aws_iam_role.prometheus[local.primary_role_index].name
-  policy_arn = aws_iam_policy.prometheus_ecs_exec[local.primary_role_index].arn
+  role       = aws_iam_role.prometheus.name
+  policy_arn = aws_iam_policy.prometheus_ecs_exec.arn
 }
 
 resource "aws_iam_policy" "prometheus_ecs_exec" {
-  count       = local.is_management_env ? 1 : 0
   name        = "PrometheusECSExecPolicy"
   description = "Allow Prometheus container to exec from cli"
   policy      = data.aws_iam_policy_document.prometheus_ecs_exec.json

--- a/prometheus_iam.tf
+++ b/prometheus_iam.tf
@@ -161,3 +161,33 @@ data "aws_iam_policy_document" "monitoring_bucket_read_write" {
     ]
   }
 }
+
+resource "aws_iam_role_policy_attachment" "prometheus_ecs_exec" {
+  count      = local.is_management_env ? 1 : 0
+  role       = aws_iam_role.prometheus[local.primary_role_index].name
+  policy_arn = aws_iam_policy.prometheus_ecs_exec[local.primary_role_index].arn
+}
+
+resource "aws_iam_policy" "prometheus_ecs_exec" {
+  count       = local.is_management_env ? 1 : 0
+  name        = "PrometheusECSExecPolicy"
+  description = "Allow Prometheus container to exec from cli"
+  policy      = data.aws_iam_policy_document.prometheus_ecs_exec.json
+}
+
+data "aws_iam_policy_document" "prometheus_ecs_exec" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/reserved_container_definition.tpl
+++ b/reserved_container_definition.tpl
@@ -8,6 +8,9 @@
   "networkMode": "awsvpc",
   "user": "${user}",
   "essential": ${essential},
+  "linuxParameters": {
+    "initProcessEnabled": true
+  }
   "portMappings": ${jsonencode([
     for port in jsondecode(ports) : {
       containerPort = port,

--- a/reserved_container_definition.tpl
+++ b/reserved_container_definition.tpl
@@ -10,7 +10,7 @@
   "essential": ${essential},
   "linuxParameters": {
     "initProcessEnabled": true
-  }
+  },
   "portMappings": ${jsonencode([
     for port in jsondecode(ports) : {
       containerPort = port,

--- a/sdx_pushgateway_iam.tf
+++ b/sdx_pushgateway_iam.tf
@@ -17,3 +17,33 @@ data "aws_iam_policy_document" "sdx_pushgateway_assume_role" {
     }
   }
 }
+
+resource "aws_iam_role_policy_attachment" "sdx_pushgateway_ecs_exec" {
+  count      = local.is_management_env ? 0 : 1
+  role       = aws_iam_role.sdx_pushgateway[local.primary_role_index].name
+  policy_arn = aws_iam_policy.sdx_pushgateway_ecs_exec[local.primary_role_index].arn
+}
+
+resource "aws_iam_policy" "sdx_pushgateway_ecs_exec" {
+  count       = local.is_management_env ? 0 : 1
+  name        = "SDXPushgatewayECSExecPolicy"
+  description = "Allow SDXPushgateway container to exec from cli"
+  policy      = data.aws_iam_policy_document.sdx_pushgateway_ecs_exec.json
+}
+
+data "aws_iam_policy_document" "sdx_pushgateway_ecs_exec" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/thanos_query_iam.tf
+++ b/thanos_query_iam.tf
@@ -68,3 +68,33 @@ data "aws_iam_policy_document" "thanos_query_read_config" {
     ]
   }
 }
+
+resource "aws_iam_role_policy_attachment" "thanos_query_ecs_exec" {
+  count      = local.is_management_env ? 1 : 0
+  role       = aws_iam_role.thanos_query[local.primary_role_index].name
+  policy_arn = aws_iam_policy.thanos_query_ecs_exec[local.primary_role_index].arn
+}
+
+resource "aws_iam_policy" "thanos_query_ecs_exec" {
+  count       = local.is_management_env ? 1 : 0
+  name        = "ThanosQueryECSExecPolicy"
+  description = "Allow ThanosQuery container to exec from cli"
+  policy      = data.aws_iam_policy_document.thanos_query_ecs_exec.json
+}
+
+data "aws_iam_policy_document" "thanos_query_ecs_exec" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/thanos_ruler_iam.tf
+++ b/thanos_ruler_iam.tf
@@ -74,3 +74,33 @@ resource "aws_iam_role_policy_attachment" "thanos_ruler_monitoring_bucket_read_w
   role       = aws_iam_role.thanos_ruler[0].name
   policy_arn = aws_iam_policy.monitoring_bucket_read_write.arn
 }
+
+resource "aws_iam_role_policy_attachment" "thanos_ruler_ecs_exec" {
+  count      = local.is_management_env ? 1 : 0
+  role       = aws_iam_role.thanos_ruler[local.primary_role_index].name
+  policy_arn = aws_iam_policy.thanos_ruler_ecs_exec[local.primary_role_index].arn
+}
+
+resource "aws_iam_policy" "thanos_ruler_ecs_exec" {
+  count       = local.is_management_env ? 1 : 0
+  name        = "ThanosRulerECSExecPolicy"
+  description = "Allow ThanosRuler container to exec from cli"
+  policy      = data.aws_iam_policy_document.thanos_ruler_ecs_exec.json
+}
+
+data "aws_iam_policy_document" "thanos_ruler_ecs_exec" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/thanos_store_iam.tf
+++ b/thanos_store_iam.tf
@@ -74,3 +74,33 @@ resource "aws_iam_role_policy_attachment" "thanos_store_monitoring_bucket_read_w
   role       = aws_iam_role.thanos_store[0].name
   policy_arn = aws_iam_policy.monitoring_bucket_read_write.arn
 }
+
+resource "aws_iam_role_policy_attachment" "thanos_store_ecs_exec" {
+  count      = local.is_management_env ? 1 : 0
+  role       = aws_iam_role.thanos_store[local.primary_role_index].name
+  policy_arn = aws_iam_policy.thanos_store_ecs_exec[local.primary_role_index].arn
+}
+
+resource "aws_iam_policy" "thanos_store_ecs_exec" {
+  count       = local.is_management_env ? 1 : 0
+  name        = "ThanosStoreECSExecPolicy"
+  description = "Allow ThanosStore container to exec from cli"
+  policy      = data.aws_iam_policy_document.thanos_store_ecs_exec.json
+}
+
+data "aws_iam_policy_document" "thanos_store_ecs_exec" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -271,5 +271,5 @@ variable "metrics_ecs_cluster_ec2_size" {
 variable "ecs_hardened_ami_id" {
   description = "The AMI ID of the latest/pinned ECS Hardened AMI Image"
   type        = string
-  default     = "ami-049bba1a08b31ff8e"
+  default     = "ami-014a6060ae79e83df"
 }


### PR DESCRIPTION
Pins version to AMI with the latest ECS Agent. This agent allows ECS Exec via the CLI. Added direct debugging to containers running in ECS EC2 and Fargate.

* Adds IAM permissions for each container
* Adds recommended recommended task definition parameter
* Unfortunately unsupported by TF and can not pass the command to enable it.