### PR TITLE
hopefully use the slave vpc, not master

### DIFF
--- a/common_dns.tf
+++ b/common_dns.tf
@@ -225,14 +225,14 @@ resource "aws_route53_zone_association" "monitoring" {
 
 resource "aws_route53_vpc_association_authorization" "sdx_services" {
   count   = local.is_management_env ? 0 : 1
-  vpc_id  = local.is_management_env ? null_resource.dummy.id : data.terraform_remote_state.management_dmi.outputs.vpcs[0].id
+  vpc_id  = local.is_management_env ? null_resource.dummy.id : module.vpc.outputs.vpcs[0].id
   zone_id = aws_service_discovery_private_dns_namespace.sdx_services[0].hosted_zone
 }
 
 resource "aws_route53_zone_association" "sdx_services" {
   count      = local.is_management_env ? 0 : 1
   provider   = aws.management_zone
-  vpc_id     = local.is_management_env ? null_resource.dummy.id : data.terraform_remote_state.management_dmi.outputs.vpcs[0].id
+  vpc_id     = local.is_management_env ? null_resource.dummy.id : module.vpc.outputs.vpcs[0].id
   zone_id    = local.is_management_env ? null_resource.dummy.id : local.sdx_dns_zone_ids[local.environment]
   depends_on = [aws_route53_vpc_association_authorization.sdx_services]
 }


### PR DESCRIPTION
It was getting the master VPC from the outputs.  Testing locally, this gets the slave VPC.  It should be the same in CI.