### PR TITLE
Surface pro access

### DIFF
--- a/terraform.tfvars.j2
+++ b/terraform.tfvars.j2
@@ -7,7 +7,6 @@ whitelist_cidr_blocks    = [
   {% endfor %}
   "{{ucfs["team_cidr_block"]}}"
 ]
-whitelist_cidr_blocks    = ["{{ucfs["team_cidr_block"]}}"]
 internet_proxy_port      = {{ports.internet_proxy_port}}
 grafana_port             = {{ports.grafana_port}}
 prometheus_port          = {{ports.prometheus_port}}

--- a/terraform.tfvars.j2
+++ b/terraform.tfvars.j2
@@ -1,11 +1,8 @@
 assume_role              = "administrator"
 parent_domain_name       = "{{dataworks_domain_name}}"
-whitelist_cidr_blocks    = [
-  {% set doiranges = doi["cidr_blocks"].split(',') %}
-  {% for cidr in doiranges %}
-  "{{ cidr }}",
-  {% endfor %}
-  "{{ucfs["team_cidr_block"]}}"
+whitelist_cidr_blocks    = [{% set doiranges = doi["cidr_blocks"].split(',') %}
+  {% for cidr in doiranges %}"{{ cidr }}",
+  {% endfor %}"{{ucfs["team_cidr_block"]}}"
 ]
 internet_proxy_port      = {{ports.internet_proxy_port}}
 grafana_port             = {{ports.grafana_port}}

--- a/terraform.tfvars.j2
+++ b/terraform.tfvars.j2
@@ -1,6 +1,13 @@
 assume_role              = "administrator"
 parent_domain_name       = "{{dataworks_domain_name}}"
-whitelist_cidr_blocks    = ["{{ucfs['team_cidr_block']}}"]
+whitelist_cidr_blocks    = [
+  {% set doiranges = doi["cidr_blocks"].split(',') %}
+  {% for cidr in doiranges %}
+  "{{ cidr }}",
+  {% endfor %}
+  "{{ucfs["team_cidr_block"]}}"
+]
+whitelist_cidr_blocks    = ["{{ucfs["team_cidr_block"]}}"]
 internet_proxy_port      = {{ports.internet_proxy_port}}
 grafana_port             = {{ports.grafana_port}}
 prometheus_port          = {{ports.prometheus_port}}


### PR DESCRIPTION
Adds the IP ranges used by Surface Pros to the whitelist.  This should enable those users to access the public service dashboard on Grafana.