### PR TITLE
Vpc sg mixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,5 @@ The drawback is that as we are routing the queries through the query node, there
 
 ![Current Architecture](docs/metrics_architecture_080121.png)
 
+## Uncommon Dependancies
+When creating new services to consume `internal-compute`, all work should be carried out and applied in this repo, before adding the remote state to the `interface_vpce_source_security_group_ids` list in the `internal-compute` [VPC](https://git.ucd.gpn.gov.uk/dip/aws-internal-compute/blob/c73d0a6a159debe59795d5be6b99c3f947414eeb/vpc.tf#L19), otherwise co flicts occurr which break applies.

--- a/cluster_sg.tf
+++ b/cluster_sg.tf
@@ -30,17 +30,6 @@ resource "aws_security_group_rule" "allow_metrics_cluster_egress_adg_pushgateway
   source_security_group_id = aws_security_group.adg_pushgateway[0].id
 }
 
-resource "aws_security_group_rule" "allow_metrics_cluster_egress_clive_pushgateway" {
-  count                    = local.is_management_env ? 0 : 1
-  description              = "Allows metrics cluster to access Clive pushgateway"
-  type                     = "egress"
-  protocol                 = "tcp"
-  from_port                = var.pushgateway_port
-  to_port                  = var.pushgateway_port
-  security_group_id        = aws_security_group.metrics_cluster.id
-  source_security_group_id = aws_security_group.clive_pushgateway[0].id
-}
-
 resource "aws_security_group_rule" "allow_metrics_cluster_egress_sdx_pushgateway" {
   count                    = local.is_management_env ? 0 : 1
   description              = "Allows metrics cluster to access SDX pushgateway"

--- a/variables.tf
+++ b/variables.tf
@@ -99,7 +99,7 @@ variable "query_cpu" {
 
 variable "query_memory" {
   default = {
-    management     = "16384"
+    management     = "8192"
     management-dev = "8192"
   }
 }


### PR DESCRIPTION
The ADG SG actually handles all traffic on `9100` to Internal Compute VPC.  This needs renaming/refactoring for all VPCs in their peering, rather than per service.