### PR TITLE
Missing SG rules for K2HB which is EC2 and claimant kafka consumer, w…

### DIFF
--- a/ingest_pushgateway_sg.tf
+++ b/ingest_pushgateway_sg.tf
@@ -28,7 +28,7 @@ resource "aws_security_group_rule" "allow_k2hb_ingress_ingest_pushgateway" {
   from_port                = var.pushgateway_port
   to_port                  = var.pushgateway_port
   security_group_id        = data.terraform_remote_state.aws_ingestion.outputs.ingestion_vpc.vpce_security_groups.ingest_pushgateway_security_group.id
-  source_security_group_id = data.terraform_remote_state.aws_ingest-consumers.outputs.security_group.k2hb_common
+  source_security_group_id = data.terraform_remote_state.aws_ingest_consumers.outputs.security_group.k2hb_common
 }
 
 resource "aws_security_group_rule" "allow_k2hb_egress_ingest_pushgateway" {
@@ -38,7 +38,7 @@ resource "aws_security_group_rule" "allow_k2hb_egress_ingest_pushgateway" {
   protocol                 = "tcp"
   from_port                = var.pushgateway_port
   to_port                  = var.pushgateway_port
-  security_group_id        = data.terraform_remote_state.aws_ingest-consumers.outputs.security_group.k2hb_common
+  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.security_group.k2hb_common
   source_security_group_id = data.terraform_remote_state.aws_ingestion.outputs.ingestion_vpc.vpce_security_groups.ingest_pushgateway_security_group.id
 }
 

--- a/peering_ingestion.tf
+++ b/peering_ingestion.tf
@@ -27,7 +27,7 @@ resource "aws_security_group_rule" "k2hb_allow_ingress_prometheus" {
   protocol                 = "tcp"
   from_port                = 9100
   to_port                  = 9100
-  security_group_id        = data.terraform_remote_state.aws_ingest-consumers.outputs.security_group.k2hb_common
+  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.security_group.k2hb_common
   source_security_group_id = aws_security_group.prometheus.id
 }
 
@@ -39,5 +39,93 @@ resource "aws_security_group_rule" "prometheus_allow_egress_k2hb" {
   from_port                = 9100
   to_port                  = 9100
   security_group_id        = aws_security_group.prometheus.id
-  source_security_group_id = data.terraform_remote_state.aws_ingest-consumers.outputs.security_group.k2hb_common
+  source_security_group_id = data.terraform_remote_state.aws_ingest_consumers.outputs.security_group.k2hb_common
+}
+
+resource "aws_security_group_rule" "k2hb_node_allow_ingress_prometheus" {
+  count                    = local.is_management_env ? 0 : 1
+  description              = "Allow prometheus ${var.secondary} to access k2hb node metrics"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 9100
+  to_port                  = 9100
+  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.k2hb_common
+  source_security_group_id = aws_security_group.prometheus.id
+}
+
+resource "aws_security_group_rule" "k2hb_allow_ingress_prometheus" {
+  count                    = local.is_management_env ? 0 : 1
+  description              = "Allow prometheus ${var.secondary} to access k2hb metrics"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = var.prometheus_port
+  to_port                  = var.prometheus_port
+  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.k2hb_common
+  source_security_group_id = aws_security_group.prometheus.id
+}
+
+resource "aws_security_group_rule" "k2hb_namenode_allow_ingress_prometheus" {
+  count                    = local.is_management_env ? 0 : 1
+  description              = "Allow prometheus ${var.secondary} to access k2hb namenode metrics"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 7101
+  to_port                  = 7101
+  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.k2hb_common
+  source_security_group_id = aws_security_group.prometheus.id
+}
+
+resource "aws_security_group_rule" "k2hb_datanode_allow_ingress_prometheus" {
+  count                    = local.is_management_env ? 0 : 1
+  description              = "Allow prometheus ${var.secondary} to access k2hb datanode metrics"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 7103
+  to_port                  = 7103
+  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.k2hb_common
+  source_security_group_id = aws_security_group.prometheus.id
+}
+
+resource "aws_security_group_rule" "k2hb_resoucre_manager_allow_ingress_prometheus" {
+  count                    = local.is_management_env ? 0 : 1
+  description              = "Allow prometheus ${var.secondary} to access k2hb yarn resource manager metrics"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 7105
+  to_port                  = 7105
+  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.k2hb_common
+  source_security_group_id = aws_security_group.prometheus.id
+}
+
+resource "aws_security_group_rule" "k2hb_node_manager_allow_ingress_prometheus" {
+  count                    = local.is_management_env ? 0 : 1
+  description              = "Allow prometheus ${var.secondary} to access k2hb yarn node manager metrics"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 7107
+  to_port                  = 7107
+  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.k2hb_common
+  source_security_group_id = aws_security_group.prometheus.id
+}
+
+resource "aws_security_group_rule" "claimant_api_kafka_consumers_allow_ingress_prometheus" {
+  count                    = local.is_management_env ? 0 : 1
+  description              = "Allow prometheus ${var.secondary} to access ingest claimant api kafka consumers ec2 node metrics"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 9100
+  to_port                  = 9100
+  security_group_id        = data.terraform_remote_state.aws_ucfs_claimant_consumer.outputs.claimant_api_kafka_consumer_sg.id
+  source_security_group_id = aws_security_group.prometheus.id
+}
+
+resource "aws_security_group_rule" "prometheus_allow_egress_claimant_api_kafka_consumers" {
+  count                    = local.is_management_env ? 0 : 1
+  description              = "Allow prometheus ${var.secondary} to access ingest claimant api kafka consumers ec2 node metrics"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = 9100
+  to_port                  = 9100
+  security_group_id        = aws_security_group.prometheus.id
+  source_security_group_id = data.terraform_remote_state.aws_ucfs_claimant_consumer.outputs.claimant_api_kafka_consumer_sg.id
 }

--- a/peering_ingestion.tf
+++ b/peering_ingestion.tf
@@ -42,28 +42,6 @@ resource "aws_security_group_rule" "prometheus_allow_egress_k2hb" {
   source_security_group_id = data.terraform_remote_state.aws_ingest_consumers.outputs.security_group.k2hb_common
 }
 
-resource "aws_security_group_rule" "k2hb_node_allow_ingress_prometheus" {
-  count                    = local.is_management_env ? 0 : 1
-  description              = "Allow prometheus ${var.secondary} to access k2hb node metrics"
-  type                     = "ingress"
-  protocol                 = "tcp"
-  from_port                = 9100
-  to_port                  = 9100
-  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.k2hb_common
-  source_security_group_id = aws_security_group.prometheus.id
-}
-
-resource "aws_security_group_rule" "k2hb_allow_ingress_prometheus" {
-  count                    = local.is_management_env ? 0 : 1
-  description              = "Allow prometheus ${var.secondary} to access k2hb metrics"
-  type                     = "ingress"
-  protocol                 = "tcp"
-  from_port                = var.prometheus_port
-  to_port                  = var.prometheus_port
-  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.k2hb_common
-  source_security_group_id = aws_security_group.prometheus.id
-}
-
 resource "aws_security_group_rule" "k2hb_namenode_allow_ingress_prometheus" {
   count                    = local.is_management_env ? 0 : 1
   description              = "Allow prometheus ${var.secondary} to access k2hb namenode metrics"
@@ -71,7 +49,7 @@ resource "aws_security_group_rule" "k2hb_namenode_allow_ingress_prometheus" {
   protocol                 = "tcp"
   from_port                = 7101
   to_port                  = 7101
-  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.k2hb_common
+  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.security_group.k2hb_common
   source_security_group_id = aws_security_group.prometheus.id
 }
 
@@ -82,7 +60,7 @@ resource "aws_security_group_rule" "k2hb_datanode_allow_ingress_prometheus" {
   protocol                 = "tcp"
   from_port                = 7103
   to_port                  = 7103
-  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.k2hb_common
+  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.security_group.k2hb_common
   source_security_group_id = aws_security_group.prometheus.id
 }
 
@@ -93,7 +71,7 @@ resource "aws_security_group_rule" "k2hb_resoucre_manager_allow_ingress_promethe
   protocol                 = "tcp"
   from_port                = 7105
   to_port                  = 7105
-  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.k2hb_common
+  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.security_group.k2hb_common
   source_security_group_id = aws_security_group.prometheus.id
 }
 
@@ -104,7 +82,7 @@ resource "aws_security_group_rule" "k2hb_node_manager_allow_ingress_prometheus" 
   protocol                 = "tcp"
   from_port                = 7107
   to_port                  = 7107
-  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.k2hb_common
+  security_group_id        = data.terraform_remote_state.aws_ingest_consumers.outputs.security_group.k2hb_common
   source_security_group_id = aws_security_group.prometheus.id
 }
 

--- a/terraform.tf.j2
+++ b/terraform.tf.j2
@@ -207,7 +207,7 @@ data "terraform_remote_state" "aws_analytical_env_app" {
   }
 }
 
-data "terraform_remote_state" "aws_ingest-consumers" {
+data "terraform_remote_state" "aws_ingest_consumers" {
   backend   = "s3"
   workspace = lookup(local.common_workspace, terraform.workspace)
 


### PR DESCRIPTION
Missing SG rules for K2HB which is EC2 and claimant kafka consumer, which is ECS