### PR TITLE
Use the right output for the route table

### DIFF
--- a/peering_ucfs_claimant.tf
+++ b/peering_ucfs_claimant.tf
@@ -8,7 +8,7 @@ resource "aws_vpc_peering_connection" "ucfs_claimant" {
 
 resource "aws_route" "ucfs_claimant_prometheus" {
   count                     = local.is_management_env ? 0 : 1
-  route_table_id            = data.terraform_remote_state.ucfs-claimant.outputs.ucfs_claimant_api_vpc.vpc.default_route_table_id
+  route_table_id            = data.terraform_remote_state.ucfs-claimant.outputs.route_tables.ucfs_claimant_api.id
   destination_cidr_block    = local.cidr_block[local.environment].mon-slave-vpc
   vpc_peering_connection_id = aws_vpc_peering_connection.ucfs_claimant[0].id
 }


### PR DESCRIPTION
Use the right output for the route table