### PR TITLE
DW-6010 certificates location

### DIFF
--- a/cert_metrics_ecs.tf
+++ b/cert_metrics_ecs.tf
@@ -88,6 +88,14 @@ data "template_file" "cert_retriever_definition" {
         "value" : "/certificates"
       },
       {
+        "name" : "ADDITIONAL_CERTS_BUCKET",
+        "value" : data.terraform_remote_state.aws_sdx.outputs.sdx_mitm_service_1_cert.bucket
+      },
+      {
+        "name" : "ADDITIONAL_CERTS_PREFIXES",
+        "value" : join(",", local.certs_prefixes)
+      },
+      {
         name  = "PROMETHEUS",
         value = "true"
       }

--- a/terraform.tf.j2
+++ b/terraform.tf.j2
@@ -695,7 +695,11 @@ locals {
       preprod     = "{{mongo_latest_dns_zone_ids.preprod}}"
       production  = "{{mongo_latest_dns_zone_ids.production}}"
   }
+
+  certs_prefixes = ["server_certificates", "ca_certificates"]
+
 }
+
 
 data "aws_iam_user" "breakglass" {
   user_name = "breakglass"


### PR DESCRIPTION
Cert-retriever will look for .pem files in the specified bucket and paths.

https://s3.console.aws.amazon.com/s3/buckets/dw-development-public-certificates?region=eu-west-2&tab=objects

added prefixes: "server_certificates", "ca_certificates".