### PR TITLE
Assign CPU correctly

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -44,7 +44,7 @@ variable "prometheus_task_cpu" {
     qa             = "4096"
     integration    = "4096"
     preprod        = "4096"
-    production     = "16384"
+    production     = "10240"
     management     = "4096"
     management-dev = "4096"
   }


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html

> For task definitions that only specify EC2 for the requiresCompatibilities parameter, the supported CPU values are between 128 CPU units (0.125 vCPUs) and 10240 CPU units (10 vCPUs). The memory value must be an integer and the limit is dependent upon the amount of available memory on the underlying Amazon EC2 instance you use.

